### PR TITLE
Bukkit&kyori dependency

### DIFF
--- a/src/main/java/com/eternalcode/core/EternalCore.java
+++ b/src/main/java/com/eternalcode/core/EternalCore.java
@@ -89,7 +89,7 @@ public final class EternalCore extends JavaPlugin {
         this.scoreboardManager = new ScoreboardManager(this, configurationManager);
         this.scoreboardManager.updateTask();
 
-        this.chatManager = new ChatManager(configurationManager);
+        this.chatManager = new ChatManager(configurationManager.getPluginConfiguration());
 
         MessagesConfiguration config = configurationManager.getMessagesConfiguration();
 

--- a/src/main/java/com/eternalcode/core/chat/ChatManager.java
+++ b/src/main/java/com/eternalcode/core/chat/ChatManager.java
@@ -4,7 +4,6 @@ import com.eternalcode.core.configuration.ConfigurationManager;
 import com.eternalcode.core.configuration.PluginConfiguration;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import org.bukkit.entity.Player;
 
 import java.util.Collections;
 import java.util.Map;
@@ -26,8 +25,8 @@ public final class ChatManager {
             .build();
     }
 
-    public void useChat(Player player) {
-        this.slowdown.put(player.getUniqueId(), (long) (System.currentTimeMillis() + this.chatDelay * 1000L));
+    public void useChat(UUID userUuid) {
+        this.slowdown.put(userUuid, (long) (System.currentTimeMillis() + this.chatDelay * 1000L));
     }
 
     public boolean isChatEnabled() {
@@ -38,12 +37,12 @@ public final class ChatManager {
         this.chatEnabled = chatEnabled;
     }
 
-    public boolean isSlowedOnChat(Player player) {
-        return slowdown.asMap().getOrDefault(player.getUniqueId(), 0L) > System.currentTimeMillis();
+    public boolean isSlowedOnChat(UUID userUuid) {
+        return slowdown.asMap().getOrDefault(userUuid, 0L) > System.currentTimeMillis();
     }
 
-    public long getSlowDown(Player player) {
-        return Math.max(slowdown.asMap().getOrDefault(player.getUniqueId(), 0L) - System.currentTimeMillis(), 0L);
+    public long getSlowDown(UUID userUuid) {
+        return Math.max(slowdown.asMap().getOrDefault(userUuid, 0L) - System.currentTimeMillis(), 0L);
     }
 
     public double getChatDelay() {

--- a/src/main/java/com/eternalcode/core/chat/ChatManager.java
+++ b/src/main/java/com/eternalcode/core/chat/ChatManager.java
@@ -15,8 +15,7 @@ public final class ChatManager {
     private double chatDelay;
     private boolean chatEnabled;
 
-    public ChatManager(ConfigurationManager configManager) {
-        PluginConfiguration config = configManager.getPluginConfiguration();
+    public ChatManager(PluginConfiguration config) {
 
         this.chatDelay = config.chatSlowMode;
         this.chatEnabled = config.chatStatue;

--- a/src/main/java/com/eternalcode/core/chat/ChatUtils.java
+++ b/src/main/java/com/eternalcode/core/chat/ChatUtils.java
@@ -14,6 +14,7 @@ import panda.std.stream.PandaStream;
 import java.util.List;
 
 public final class ChatUtils {
+
     private static final LegacyComponentSerializer serializer = PaperComponents.legacySectionSerializer();
 
     public static String color(String text) {

--- a/src/main/java/com/eternalcode/core/chat/PlayerChatListener.java
+++ b/src/main/java/com/eternalcode/core/chat/PlayerChatListener.java
@@ -8,6 +8,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
+import java.util.UUID;
+
 public class PlayerChatListener implements Listener {
 
     private final ChatManager chatManager;
@@ -29,14 +31,16 @@ public class PlayerChatListener implements Listener {
             return;
         }
 
-        if (this.chatManager.isSlowedOnChat(player) && !player.hasPermission("enernalCore.chat.noslowmode")) {
-            long time = this.chatManager.getSlowDown(player);
+        UUID uuid = player.getUniqueId();
+
+        if (this.chatManager.isSlowedOnChat(uuid) && !player.hasPermission("enernalCore.chat.noslowmode")) {
+            long time = this.chatManager.getSlowDown(uuid);
 
             player.sendMessage(ChatUtils.color(messages.chatSlowMode.replace("{TIME}", DateUtils.durationToString(time))));
             event.setCancelled(true);
             return;
         }
 
-        this.chatManager.useChat(player);
+        this.chatManager.useChat(uuid);
     }
 }

--- a/src/main/java/com/eternalcode/core/command/implementations/GcCommand.java
+++ b/src/main/java/com/eternalcode/core/command/implementations/GcCommand.java
@@ -15,7 +15,6 @@ import org.bukkit.entity.Player;
 
 import java.util.List;
 
-
 @FunnyComponent
 public final class GcCommand {
     @FunnyCommand(
@@ -27,6 +26,8 @@ public final class GcCommand {
     )
 
     public void execute(Player player) {
+        //TODO: :skull:
+
         player.sendMessage(ChatUtils.color("&8[&e⭐&8]"));
         player.sendMessage(ChatUtils.color("&8[&e⭐&8] &7TPS from last 1m, 5m, 15m: " + BenchmarkUtils.getTPS()));
         player.sendMessage(ChatUtils.color("&8[&e⭐&8]"));

--- a/src/main/java/com/eternalcode/core/user/User.java
+++ b/src/main/java/com/eternalcode/core/user/User.java
@@ -5,10 +5,10 @@
 package com.eternalcode.core.user;
 
 import com.eternalcode.core.chat.ChatUtils;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.title.Title;
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
+import net.kyori.adventure.text.Component; // to remove
+import net.kyori.adventure.title.Title; // to remove
+import org.bukkit.Bukkit; // to remove
+import org.bukkit.entity.Player; // to remove
 import panda.std.Option;
 import panda.utilities.StringUtils;
 
@@ -36,18 +36,22 @@ public class User {
         return uuid;
     }
 
+    @Deprecated
     public void ifOnline(Consumer<Player> playerConsumer) {
         Option.of(Bukkit.getPlayer(name)).peek(playerConsumer);
     }
 
+    @Deprecated
     public void message(String message) {
         ifOnline(player -> player.sendMessage(ChatUtils.color(message)));
     }
 
+    @Deprecated
     public void actionBar(String message) {
         ifOnline(player -> player.sendActionBar(Component.text(ChatUtils.color(message))));
     }
 
+    @Deprecated
     public void title(String title, String subTitle, long in, long stay, long out) {
         Function<Long, Duration> calcDuration = integer -> Duration.of(integer * 50, ChronoUnit.MILLIS);
         Title.Times times = Title.Times.of(calcDuration.apply(in), calcDuration.apply(stay), calcDuration.apply(out));
@@ -56,10 +60,12 @@ public class User {
         ifOnline(player -> player.showTitle(titleComponent));
     }
 
+    @Deprecated
     public void title(String title, long in, long stay, long out) {
         title(title, StringUtils.EMPTY, in, stay, out);
     }
 
+    @Deprecated
     public void subTitle(String subTitle, long in, long stay, long out) {
         title(StringUtils.EMPTY, subTitle, in, stay, out);
     }

--- a/src/main/java/com/eternalcode/core/user/UserService.java
+++ b/src/main/java/com/eternalcode/core/user/UserService.java
@@ -4,8 +4,8 @@
 
 package com.eternalcode.core.user;
 
-import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer; // to remove
+import org.bukkit.entity.Player; // to remove
 import panda.std.Option;
 
 import java.util.Collection;
@@ -33,6 +33,7 @@ public class UserService {
         return Option.of(usersByName.get(name));
     }
 
+    @Deprecated
     public Option<User> getUser(OfflinePlayer player) {
         return getUser(player.getUniqueId());
     }
@@ -41,6 +42,7 @@ public class UserService {
         return create(uuid, name).orElseGet(usersByUUID.get(uuid));
     }
 
+    @Deprecated
     public User getOrCreate(Player player) {
         return getOrCreate(player.getUniqueId(), player.getName());
     }


### PR DESCRIPTION
Hej... Ogólnie to czemu chcę usunąć z User, UserManager, ChatManager zależności od Minecraft?
Odpowiedź jest prosta: Tego kodu nie da się swobodnie testować (trzeba robić mocki i dodawać bukkit api) i nagina to założenia wzorca projektowego [Dependency inversion principle](https://en.wikipedia.org/wiki/Dependency_inversion_principle). Kod modelu tzn. np. User, Order, Invite, ChatManager itd. jest kodem wysokiej ważności i nie powinien być zależny od minecrafta.

Prosty przykład, zakładamy że chcę przetestować ChatManager w testach jednostkowych na starym kodzie wymagało by to Playera, co oznacza że musimy mockować API Bukkita i się bawić w tego typu rzeczy.
![image](https://user-images.githubusercontent.com/49173834/150992776-a29d03f7-238a-4d60-aedc-8e459826a4af.png)
Po zamianach możemy bez problemu używać metod z ChatManager tworząc sobie nowe UUID.

