### PR TITLE
GH-233 Add command template for command config

### DIFF
--- a/eternalcore/src/main/java/com/eternalcode/core/command/configurator/CommandConfiguration.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/command/configurator/CommandConfiguration.java
@@ -2,6 +2,7 @@ package com.eternalcode.core.command.configurator;
 
 import com.eternalcode.core.configuration.ReloadableConfig;
 import net.dzikoysk.cdn.entity.Contextual;
+import net.dzikoysk.cdn.entity.Description;
 import net.dzikoysk.cdn.source.Resource;
 import net.dzikoysk.cdn.source.Source;
 
@@ -15,6 +16,19 @@ public class CommandConfiguration implements ReloadableConfig {
     public Resource resource(File folder) {
         return Source.of(folder, "commands.yml");
     }
+
+    @Description({
+        "# This file allows you to configure commands.",
+        "# You can change command name, aliases and permissions.",
+        "# You can edit the commands as follows this template:",
+        "# commands:",
+        "#   <command_name>:",
+        "#     name: \"<new_command_name>\"",
+        "#     aliases:",
+        "#       - \"<new_command_aliases>\"",
+        "#     permissions:",
+        "#       - \"<new_command_permission>\"",
+    })
 
     public Map<String, Command> commands = Map.of(
         "eternalcore", new Command("eternal-core", List.of("eternal"), List.of("eternalcore.eternalcore"))


### PR DESCRIPTION
Hi, im add template to add custom command config for command configurator

Result:
```yaml
# This file allows you to configure commands.
# You can change command name, aliases and permissions.
# You can edit the commands as follows this template:
# commands:
#   <command_name>:
#     name: "<new_command_name>"
#     aliases:
#       - "<new_command_aliases>"
#     permissions:
#       - "<new_command_permission>"
commands:
  eternalcore:
    name: "eternal-core"
    aliases:
      - "eternal"
    permissions:
      - "eternalcore.eternalcore"
```      