### PR TITLE
GH-287 Exclude "cooldown"

### DIFF
--- a/eternalcore/src/main/java/com/eternalcode/core/chat/feature/reportchat/HelpOpCommand.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/chat/feature/reportchat/HelpOpCommand.java
@@ -50,7 +50,7 @@ public class HelpOpCommand {
 
             this.noticeService
                 .create()
-                .notice(translation -> translation.helpOp().coolDown())
+                .notice(translation -> translation.helpOp().helpOpDelay())
                 .placeholder("{TIME}", DurationUtil.format(time))
                 .player(player.getUniqueId())
                 .send();

--- a/eternalcore/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -124,13 +124,13 @@ public class PluginConfiguration implements ReloadableConfig {
     @Contextual
     public static class Chat implements ChatSettings {
 
-        @Description({ " ", "# Cooldown time for helpop message" })
+        @Description({ " ", "# Delay to send the next message under /helpop" })
         public Duration helpOpDelay = Duration.ofSeconds(60);
 
         @Description({ " ", "# Custom message for unknown command" })
         public boolean commandExact = false;
 
-        @Description({ " ", "# Cooldowon time for chat" })
+        @Description({ " ", "# Chat delay to send next message in chat" })
         public Duration chatDelay = Duration.ofSeconds(5);
 
         @Description({ " ", "# Count of lines to clear" })

--- a/eternalcore/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -42,7 +42,7 @@ public interface Translation {
     interface HelpOpSection {
         Notification format();
         Notification send();
-        Notification coolDown();
+        Notification helpOpDelay();
     }
 
     // AdminChat Section

--- a/eternalcore/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -58,7 +58,7 @@ public class ENTranslation extends AbstractTranslation {
     public static class ENHelpOpSection implements HelpOpSection {
         public Notification format = Notification.chat("<dark_gray>[<dark_red>HelpOp<dark_gray>] <yellow>{NICK}<dark_gray>: <white>{TEXT}");
         public Notification send = Notification.chat("<dark_gray>» <green>This message has been successfully sent to administration");
-        public Notification coolDown = Notification.chat("<dark_gray>» <red>You can use this command for: <gold>{TIME}");
+        public Notification helpOpDelay = Notification.chat("<dark_gray>» <red>You can use this command for: <gold>{TIME}");
     }
 
     public ENAdminChatSection adminChat = new ENAdminChatSection();

--- a/eternalcore/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -56,7 +56,7 @@ public class PLTranslation extends AbstractTranslation {
     public static class PLHelpOpSection implements HelpOpSection {
         public Notification format = Notification.chat("<dark_gray>[<dark_red>HelpOp<dark_gray>] <yellow>{NICK}<dark_gray>: <white>{TEXT}");
         public Notification send = Notification.chat("<dark_gray>» <green>Wiadomość została wysłana do administracji");
-        public Notification coolDown = Notification.chat("<dark_gray>» <red>Możesz użyć tej komendy dopiero za <gold>{TIME}!");
+        public Notification helpOpDelay = Notification.chat("<dark_gray>» <red>Możesz użyć tej komendy dopiero za <gold>{TIME}!");
     }
 
     public PLAdminChatSection adminChat = new PLAdminChatSection();


### PR DESCRIPTION
The name "cooldown" says very little, so I decided to exclude it in some places. In offensive language, it can be misinterpreted. "Delay" says a lot more, and sounds a lot better!