### PR TITLE
GH-434 Add teleport to spawn on death & additional check

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
@@ -107,6 +107,7 @@ import com.eternalcode.core.listener.player.PlayerDeathListener;
 import com.eternalcode.core.listener.player.PlayerJoinListener;
 import com.eternalcode.core.listener.player.PlayerLoginListener;
 import com.eternalcode.core.listener.player.PlayerQuitListener;
+import com.eternalcode.core.listener.player.PlayerRespawnListener;
 import com.eternalcode.core.listener.sign.SignChangeListener;
 import com.eternalcode.core.notification.NoticeService;
 import com.eternalcode.core.notification.NoticeType;
@@ -425,6 +426,7 @@ class EternalCore implements EternalCoreApi {
             new PlayerCommandPreprocessListener(this.noticeService, pluginConfiguration, server),
             new SignChangeListener(this.miniMessage),
             new PlayerDeathListener(this.noticeService),
+            new PlayerRespawnListener(this.teleportService, pluginConfiguration, locationsConfiguration),
             new TeleportListeners(this.noticeService, this.teleportTaskService),
             new AfkController(this.afkService),
             new PlayerLoginListener(this.translationManager, this.userManager, this.miniMessage)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
@@ -255,7 +255,7 @@ class EternalCore implements EternalCoreApi {
         this.translationManager = TranslationManager.create(this.configurationManager, languageConfiguration);
         this.noticeService = new NoticeService(this.scheduler, this.translationManager, this.viewerProvider, this.notificationAnnouncer, this.placeholderRegistry);
         this.afkService = new AfkService(pluginConfiguration.afk, this.noticeService, this.userManager);
-        this.teleportRequestService = new TeleportRequestService(pluginConfiguration.tpa);
+        this.teleportRequestService = new TeleportRequestService(pluginConfiguration.teleportAsk);
 
         /* Database */
         WarpRepository warpRepository = new WarpConfigRepository(this.configurationManager, locationsConfiguration);
@@ -356,7 +356,7 @@ class EternalCore implements EternalCoreApi {
 
                 // Tpa Commands
                 new TpaCommand(this.teleportRequestService, this.noticeService),
-                new TpaAcceptCommand(this.teleportRequestService, this.teleportTaskService, this.noticeService, pluginConfiguration.tpa, server),
+                new TpaAcceptCommand(this.teleportRequestService, this.teleportTaskService, this.noticeService, pluginConfiguration.teleportAsk, server),
                 new TpaDenyCommand(this.teleportRequestService, this.noticeService, server),
 
                 // Spawn & Warp Command

--- a/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/EternalCore.java
@@ -107,7 +107,7 @@ import com.eternalcode.core.listener.player.PlayerDeathListener;
 import com.eternalcode.core.listener.player.PlayerJoinListener;
 import com.eternalcode.core.listener.player.PlayerLoginListener;
 import com.eternalcode.core.listener.player.PlayerQuitListener;
-import com.eternalcode.core.listener.player.PlayerRespawnListener;
+import com.eternalcode.core.feature.spawn.SpawnRespawnController;
 import com.eternalcode.core.listener.sign.SignChangeListener;
 import com.eternalcode.core.notification.NoticeService;
 import com.eternalcode.core.notification.NoticeType;
@@ -426,7 +426,7 @@ class EternalCore implements EternalCoreApi {
             new PlayerCommandPreprocessListener(this.noticeService, pluginConfiguration, server),
             new SignChangeListener(this.miniMessage),
             new PlayerDeathListener(this.noticeService),
-            new PlayerRespawnListener(this.teleportService, pluginConfiguration, locationsConfiguration),
+            new SpawnRespawnController(this.teleportService, pluginConfiguration, locationsConfiguration),
             new TeleportListeners(this.noticeService, this.teleportTaskService),
             new AfkController(this.afkService),
             new PlayerLoginListener(this.translationManager, this.userManager, this.miniMessage)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -4,6 +4,7 @@ import com.eternalcode.core.configuration.ReloadableConfig;
 import com.eternalcode.core.database.DatabaseType;
 import com.eternalcode.core.feature.afk.AfkSettings;
 import com.eternalcode.core.feature.chat.ChatSettings;
+import com.eternalcode.core.teleport.Teleport;
 import com.eternalcode.core.teleport.request.TeleportRequestSettings;
 import net.dzikoysk.cdn.entity.Contextual;
 import net.dzikoysk.cdn.entity.Description;
@@ -51,10 +52,10 @@ public class PluginConfiguration implements ReloadableConfig {
     }
 
     @Description({ " ", "# Teleport request section" })
-    public Tpa tpa = new Tpa();
+    public TeleportAsk teleportAsk = new TeleportAsk();
 
     @Contextual
-    public static class Tpa implements TeleportRequestSettings {
+    public static class TeleportAsk implements TeleportRequestSettings {
         @Description("# Time of tpa requests expire")
 
         @Description({ " ", "# Time of tpa requests expire" })
@@ -75,10 +76,10 @@ public class PluginConfiguration implements ReloadableConfig {
     }
 
     @Description({" ", "# Teleport section"})
-    public Tp tp = new Tp();
+    public Teleport teleport = new Teleport();
 
     @Contextual
-    public static class Tp {
+    public static class Teleport {
 
         @Description("# Teleports the player to spawn after death")
         public boolean teleportToSpawnOnDeath = true;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -74,6 +74,16 @@ public class PluginConfiguration implements ReloadableConfig {
         }
     }
 
+    @Description({" ", "# Teleport section"})
+    public Tp tp = new Tp();
+
+    @Contextual
+    public static class Tp {
+
+        @Description("# Teleports the player to spawn after death")
+        public boolean teleportToSpawnOnDeath = true;
+    }
+
     @Description({ " ", "# Homes Section" })
     public Homes homes = new Homes();
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnRespawnController.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnRespawnController.java
@@ -1,4 +1,4 @@
-package com.eternalcode.core.listener.player;
+package com.eternalcode.core.feature.spawn;
 
 import com.eternalcode.core.configuration.implementation.LocationsConfiguration;
 import com.eternalcode.core.configuration.implementation.PluginConfiguration;
@@ -10,13 +10,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
-public class PlayerRespawnListener implements Listener {
+public class SpawnRespawnController implements Listener {
 
     private final TeleportService teleportService;
     private final PluginConfiguration config;
     private final LocationsConfiguration locations;
 
-    public PlayerRespawnListener(TeleportService teleportService, PluginConfiguration config, LocationsConfiguration locations) {
+    public SpawnRespawnController(TeleportService teleportService, PluginConfiguration config, LocationsConfiguration locations) {
         this.teleportService = teleportService;
         this.config = config;
         this.locations = locations;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerDeathListener.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerDeathListener.java
@@ -43,10 +43,15 @@ public class PlayerDeathListener implements Listener {
             return;
         }
 
+        EntityDamageEvent lastDamageCasue = player.getLastDamageCause();
+
+        if (lastDamageCasue == null) {
+            return;
+        }
 
         this.noticeService.create()
             .noticeOption(translation -> {
-                EntityDamageEvent.DamageCause cause = player.getLastDamageCause().getCause();
+                EntityDamageEvent.DamageCause cause = lastDamageCasue.getCause();
 
                 List<Notification> notifications = translation.event().deathMessageByDamageCause().get(cause);
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
@@ -23,7 +23,7 @@ public class PlayerRespawnListener implements Listener {
     }
 
     @EventHandler
-    public void onPlayerRespawn(PlayerRespawnEvent event) {
+    void onPlayerRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
 
         if (this.config.teleport.teleportToSpawnOnDeath) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
@@ -1,0 +1,35 @@
+package com.eternalcode.core.listener.player;
+
+import com.eternalcode.core.configuration.implementation.LocationsConfiguration;
+import com.eternalcode.core.configuration.implementation.PluginConfiguration;
+import com.eternalcode.core.shared.PositionAdapter;
+import com.eternalcode.core.teleport.TeleportService;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerRespawnEvent;
+
+public class PlayerRespawnListener implements Listener {
+
+    private final TeleportService teleportService;
+    private final PluginConfiguration config;
+    private final LocationsConfiguration locations;
+
+    public PlayerRespawnListener(TeleportService teleportService, PluginConfiguration config, LocationsConfiguration locations) {
+        this.teleportService = teleportService;
+        this.config = config;
+        this.locations = locations;
+    }
+
+    @EventHandler
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+
+        if (this.config.tp.teleportToSpawnOnDeath) {
+            Location destinationLocation = PositionAdapter.convert(this.locations.spawn);
+            this.teleportService.teleport(player, destinationLocation);
+        }
+    }
+
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/listener/player/PlayerRespawnListener.java
@@ -26,7 +26,7 @@ public class PlayerRespawnListener implements Listener {
     public void onPlayerRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
 
-        if (this.config.tp.teleportToSpawnOnDeath) {
+        if (this.config.teleport.teleportToSpawnOnDeath) {
             Location destinationLocation = PositionAdapter.convert(this.locations.spawn);
             this.teleportService.teleport(player, destinationLocation);
         }


### PR DESCRIPTION
PR dodaje możliwość ustawienia w configu czy gracz ma się teleportować na spawna po śmierci.
Dodałem również dodatkowego checka w PlayerDeathListener ponieważ gdy gracz użył komendy "**/kill**" wyrzucało błąd

https://github.com/EternalCodeTeam/EternalCore/pull/434/files#diff-1ff580cabf582e48ca59eeda20a77fb296faa0336a6e0df54b4d96afc3e31514