### PR TITLE
Correct spelling of 'receiving' in auto message feature

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/database/NoneRepository.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/database/NoneRepository.java
@@ -77,17 +77,17 @@ public final class NoneRepository implements HomeRepository, IgnoreRepository, A
     }
 
     @Override
-    public Completable<List<UUID>> findRecivers(List<UUID> onlineUniqueIds) {
+    public Completable<List<UUID>> findReceivers(List<UUID> onlineUniqueIds) {
         return Completable.completed(Collections.emptyList());
     }
 
     @Override
-    public Completable<Boolean> isReciving(UUID uniqueId) {
+    public Completable<Boolean> isReceiving(UUID uniqueId) {
         return Completable.completed(false);
     }
 
     @Override
-    public Completable<Boolean> switchReciving(UUID uniqueId) {
+    public Completable<Boolean> switchReceiving(UUID uniqueId) {
         return Completable.completed(false);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/database/wrapper/AutoMessageRepositoryOrmLite.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/database/wrapper/AutoMessageRepositoryOrmLite.java
@@ -21,7 +21,7 @@ public class AutoMessageRepositoryOrmLite extends AbstractRepositoryOrmLite impl
     }
 
     @Override
-    public Completable<List<UUID>> findRecivers(List<UUID> onlineUniqueIds) {
+    public Completable<List<UUID>> findReceivers(List<UUID> onlineUniqueIds) {
         if (onlineUniqueIds.isEmpty()) {
             return Completable.completed(onlineUniqueIds);
         }
@@ -44,12 +44,12 @@ public class AutoMessageRepositoryOrmLite extends AbstractRepositoryOrmLite impl
     }
 
     @Override
-    public Completable<Boolean> isReciving(UUID uniqueId) {
+    public Completable<Boolean> isReceiving(UUID uniqueId) {
         return this.selectSafe(AutoMessageIgnoreWrapper.class, uniqueId).thenApply(Optional::isEmpty);
     }
 
     @Override
-    public Completable<Boolean> switchReciving(UUID uniqueId) {
+    public Completable<Boolean> switchReceiving(UUID uniqueId) {
         return this.selectSafe(AutoMessageIgnoreWrapper.class, uniqueId).thenCompose(optional -> {
             if (optional.isEmpty()) {
                 return this.save(AutoMessageIgnoreWrapper.class, new AutoMessageIgnoreWrapper(uniqueId)).thenApply(result -> true);

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageCommand.java
@@ -22,7 +22,7 @@ public class AutoMessageCommand {
     @Execute
     @DescriptionDocs(description = "Toggles the display of automatic messages.")
     void execute(Player player) {
-        this.autoMessageService.switchReciving(player.getUniqueId()).then(receiving -> {
+        this.autoMessageService.switchReceiving(player.getUniqueId()).then(receiving -> {
             if (receiving) {
                 this.noticeService.player(player.getUniqueId(), messages -> messages.autoMessage().enabled());
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageRepository.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageRepository.java
@@ -7,11 +7,11 @@ import java.util.UUID;
 
 public interface AutoMessageRepository {
 
-    Completable<List<UUID>> findRecivers(List<UUID> onlineUniqueIds);
+    Completable<List<UUID>> findReceivers(List<UUID> onlineUniqueIds);
 
     // for nearby feafure like placeholders etc
-    Completable<Boolean> isReciving(UUID uniqueId);
+    Completable<Boolean> isReceiving(UUID uniqueId);
 
-    Completable<Boolean> switchReciving(UUID uniqueId);
+    Completable<Boolean> switchReceiving(UUID uniqueId);
 
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageService.java
@@ -37,8 +37,8 @@ public class AutoMessageService {
         this.tick();
     }
 
-    public Completable<Boolean> switchReciving(UUID uniqueId) {
-        return this.repository.switchReciving(uniqueId);
+    public Completable<Boolean> switchReceiving(UUID uniqueId) {
+        return this.repository.switchReceiving(uniqueId);
     }
 
     public void broadcastNextMessage() {
@@ -46,13 +46,13 @@ public class AutoMessageService {
             .map(Entity::getUniqueId)
             .toList();
 
-        this.repository.findRecivers(onlineUniqueIds).then(recivers -> {
-            if (recivers.isEmpty()) {
+        this.repository.findReceivers(onlineUniqueIds).then(receivers -> {
+            if (receivers.isEmpty()) {
                 return;
             }
 
             this.noticeService.create()
-                .players(recivers)
+                .players(receivers)
                 .noticeOption(translation -> this.nextAutoMessage(translation.autoMessage()))
                 .send();
         });


### PR DESCRIPTION
Multiple instances of the word 'reciving' have been corrected to 'receiving' within the auto message feature. This includes changes across multiple classes and interfaces in the application to ensure consistency and readability.

