### PR TITLE
GH-489 Reorder home limit check in SetHomeCommand

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/command/SetHomeCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/command/SetHomeCommand.java
@@ -43,19 +43,6 @@ public class SetHomeCommand {
     }
 
     private void setHome(User user, Player player, String home) {
-        int amountOfUserHomes = this.homeManager.getHomes(player.getUniqueId()).size();
-        int maxAmountOfUserHomes = this.getMaxAmountOfHomes(player);
-
-        if (amountOfUserHomes >= this.getMaxAmountOfHomes(player)) {
-            this.noticeService.create()
-                .user(user)
-                .placeholder("{LIMIT}", String.valueOf(maxAmountOfUserHomes))
-                .notice(translation -> translation.home().limit())
-                .send();
-
-            return;
-        }
-
         if (this.homeManager.hasHomeWithSpecificName(user, home)) {
             this.homeManager.createHome(user, home, player.getLocation());
 
@@ -63,6 +50,19 @@ public class SetHomeCommand {
                 .user(user)
                 .placeholder("{HOME}", home)
                 .notice(translation -> translation.home().overrideHomeLocation())
+                .send();
+
+            return;
+        }
+
+        int amountOfUserHomes = this.homeManager.getHomes(player.getUniqueId()).size();
+        int maxAmountOfUserHomes = this.getMaxAmountOfHomes(player);
+
+        if (amountOfUserHomes >= maxAmountOfUserHomes) {
+            this.noticeService.create()
+                .user(user)
+                .placeholder("{LIMIT}", String.valueOf(maxAmountOfUserHomes))
+                .notice(translation -> translation.home().limit())
                 .send();
 
             return;
@@ -76,6 +76,7 @@ public class SetHomeCommand {
             .placeholder("{HOME}", home)
             .send();
     }
+
 
     public int getMaxAmountOfHomes(Player player) {
         Map<String, Integer> maxHomes = this.pluginConfiguration.homes.maxHomes;


### PR DESCRIPTION
Changed the home set logic in **SetHomeCommand** to prioritize the existing home check before the home limit check. Previously, the user was first informed about reaching the home limit even when the existing home was being overwritten. This update modulates the sequence for improved feedback and user experience.

Fixes #489 

https://github.com/EternalCodeTeam/EternalCore/assets/65517973/c6730cb4-52c1-490f-ab3f-63614629142f

