### PR TITLE
GH-498 Fix message about helpop send, just add player uuid to sender notice.

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/reportchat/HelpOpCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/reportchat/HelpOpCommand.java
@@ -71,6 +71,7 @@ public class HelpOpCommand {
 
         this.noticeService
             .create()
+            .player(player.getUniqueId())
             .notice(translation -> translation.helpOp().send())
             .send();
 


### PR DESCRIPTION
A player unique identifier has been added to the **HelpOpCommand**, allowing the noticeService to associate messages with the player sending them.

Fixes #498 

![image](https://github.com/EternalCodeTeam/EternalCore/assets/65517973/932b8df6-3e4b-46e6-83af-451e7bf008dd)
