### PR TITLE
GH-529 Add a missing database driver for MariaDB

### DIFF
--- a/eternalcore-core/build.gradle.kts
+++ b/eternalcore-core/build.gradle.kts
@@ -38,15 +38,15 @@ eternalShadow {
     )
 
     // configuration
-    library("org.mariadb.jdbc:mariadb-java-client:3.2.0")
-    library("org.postgresql:postgresql:42.6.0")
-    library("com.h2database:h2:2.2.222")
     library("net.dzikoysk:cdn:1.14.4")
     libraryRelocate(
         "net.dzikoysk.cdn"
     )
 
     // database
+    library("org.mariadb.jdbc:mariadb-java-client:3.2.0")
+    library("org.postgresql:postgresql:42.6.0")
+    library("com.h2database:h2:2.2.222")
     library("com.j256.ormlite:ormlite-jdbc:6.1")
     library("com.zaxxer:HikariCP:5.0.1")
 

--- a/eternalcore-core/build.gradle.kts
+++ b/eternalcore-core/build.gradle.kts
@@ -40,6 +40,7 @@ eternalShadow {
     // configuration
     library("org.mariadb.jdbc:mariadb-java-client:3.2.0")
     library("org.postgresql:postgresql:42.6.0")
+    library("com.h2database:h2:2.2.222")
     library("net.dzikoysk:cdn:1.14.4")
     libraryRelocate(
         "net.dzikoysk.cdn"

--- a/eternalcore-core/build.gradle.kts
+++ b/eternalcore-core/build.gradle.kts
@@ -39,6 +39,7 @@ eternalShadow {
 
     // configuration
     library("org.mariadb.jdbc:mariadb-java-client:3.2.0")
+    library("org.postgresql:postgresql:42.6.0")
     library("net.dzikoysk:cdn:1.14.4")
     libraryRelocate(
         "net.dzikoysk.cdn"

--- a/eternalcore-core/build.gradle.kts
+++ b/eternalcore-core/build.gradle.kts
@@ -38,6 +38,7 @@ eternalShadow {
     )
 
     // configuration
+    library("org.mariadb.jdbc:mariadb-java-client:3.2.0")
     library("net.dzikoysk:cdn:1.14.4")
     libraryRelocate(
         "net.dzikoysk.cdn"


### PR DESCRIPTION
## Description
The plugin could not run, while opted to use MariaDB's, PostgreSQL's and H2's driver, because of its lack in classloader.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- [x] Plugin can successfully run, while using any of the supported drivers

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to readme etc.
- [x] My changes generate no new warnings
- [ ] I have added test to cover my changes
- [x] I have added appropriate labels to this Pull Request

