### PR TITLE
GH-545 Change the placeholder from "{SENDER}" to "{PLAYER}".

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnCommand.java
@@ -100,7 +100,7 @@ class SpawnCommand {
 
         this.noticeService.create()
             .notice(translation -> translation.spawn().spawnTeleportedBy())
-            .placeholder("{SENDER}", sender.getName())
+            .placeholder("{PLAYER}", sender.getName())
             .player(player.getUniqueId())
             .send();
 


### PR DESCRIPTION
The default message implementation in PL and EN translation is {PLAYER} but, replacement is {SENDER}, I changed this in replacement from {SENDER} to {PLAYER}, because, in my opinion, it is best and {SENDER} is not making sense.