### PR TITLE
GH-541 Add teleport to random player features (tprp command).

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -94,6 +94,9 @@ public class PluginConfiguration implements ReloadableConfig {
         @Description("# Time of teleportation to spawn")
         public Duration teleportTimeToSpawn = Duration.ofSeconds(5);
 
+        @Description("# Include players with op in teleport to random player")
+        public boolean includeOpPlayersInRandomTeleport = false;
+
         @Override
         public Duration teleportationTimeToSpawn() {
             return this.teleportTimeToSpawn;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-@Route(name = "teleport-to-random-player", aliases = { "tprp" })
+@Route(name = "teleport-to-random-player", aliases = {"tprp"})
 @Permission("eternalcore.tprp")
 public class TeleportToRandomPlayerCommand {
 
@@ -30,13 +30,13 @@ public class TeleportToRandomPlayerCommand {
     }
 
     @Execute
-    @DescriptionDocs(description = "Teleport to random player on server")
+    @DescriptionDocs(description = "Teleport to random player on server, with filter op players option")
     void execute(Player player) {
-        List<Player> applicablePlayers = this.server.getOnlinePlayers().stream()
-            .filter(players -> this.pluginConfiguration.teleport.includeOpPlayersInRandomTeleport || !players.isOp())
+        List<Player> possibleTargetPlayers = this.server.getOnlinePlayers().stream()
+            .filter(target -> this.pluginConfiguration.teleport.includeOpPlayersInRandomTeleport || !target.isOp())
             .collect(Collectors.toList());
 
-        if (applicablePlayers.isEmpty()) {
+        if (possibleTargetPlayers.isEmpty()) {
             this.noticeService.create()
                 .player(player.getUniqueId())
                 .notice(translation -> translation.teleport().noPlayerToRandomTeleportFound())
@@ -44,13 +44,13 @@ public class TeleportToRandomPlayerCommand {
             return;
         }
 
-        Player target = applicablePlayers.get(RANDOM.nextInt(applicablePlayers.size()));
+        Player randomPlayer = possibleTargetPlayers.get(RANDOM.nextInt(possibleTargetPlayers.size()));
 
-        player.teleport(target.getLocation());
+        player.teleport(randomPlayer);
         this.noticeService.create()
             .player(player.getUniqueId())
             .notice(translation -> translation.teleport().teleportedToRandomPlayer())
-            .placeholder("{PLAYER}", target.getName())
+            .placeholder("{PLAYER}", randomPlayer.getName())
             .send();
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -46,7 +46,7 @@ public class TeleportToRandomPlayerCommand {
 
         Player target = applicablePlayers.get(RANDOM.nextInt(applicablePlayers.size()));
 
-        player.teleport(target);
+        player.teleport(target.getLocation());
         this.noticeService.create()
             .player(player.getUniqueId())
             .notice(translation -> translation.teleport().teleportedToRandomPlayer())

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -1,0 +1,56 @@
+package com.eternalcode.core.feature.teleport.command;
+
+import com.eternalcode.annotations.scan.command.DescriptionDocs;
+import com.eternalcode.core.configuration.implementation.PluginConfiguration;
+import com.eternalcode.core.notice.NoticeService;
+import dev.rollczi.litecommands.command.execute.Execute;
+import dev.rollczi.litecommands.command.permission.Permission;
+import dev.rollczi.litecommands.command.route.Route;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+@Route(name = "teleport-to-random-player", aliases = {"tprp"})
+@Permission("eternalcore.tprp")
+public class TeleportToRandomPlayerCommand {
+
+    private static final Random RANDOM = new Random();
+
+    private final Server server;
+    private final PluginConfiguration pluginConfiguration;
+    private final NoticeService noticeService;
+
+    public TeleportToRandomPlayerCommand(Server server, PluginConfiguration pluginConfiguration, NoticeService noticeService) {
+        this.server = server;
+        this.pluginConfiguration = pluginConfiguration;
+        this.noticeService = noticeService;
+    }
+
+    @Execute
+    @DescriptionDocs(description = "Teleport to random player on server")
+    void execute(Player player) {
+        List<Player> applicablePlayers = this.server.getOnlinePlayers().stream()
+            .filter(players -> this.pluginConfiguration.teleport.includeOpPlayersInRandomTeleport || !players.isOp())
+            .collect(Collectors.toList());
+
+        if (applicablePlayers.isEmpty()) {
+            this.noticeService.create()
+                .player(player.getUniqueId())
+                .notice(translation -> translation.teleport().noPlayerToRandomTeleportFound())
+                .send();
+            return;
+        }
+
+        Player target = applicablePlayers.get(RANDOM.nextInt(applicablePlayers.size()));
+
+        player.teleport(target.getLocation());
+        this.noticeService.create()
+            .player(player.getUniqueId())
+            .notice(translation -> translation.teleport().teleportedToRandomPlayer())
+            .placeholder("{PLAYER}", target.getName())
+            .send();
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-@Route(name = "teleport-to-random-player", aliases = {"tprp"})
+@Route(name = "teleport-to-random-player", aliases = { "tprp" })
 @Permission("eternalcore.tprp")
 public class TeleportToRandomPlayerCommand {
 
@@ -46,7 +46,7 @@ public class TeleportToRandomPlayerCommand {
 
         Player target = applicablePlayers.get(RANDOM.nextInt(applicablePlayers.size()));
 
-        player.teleport(target.getLocation());
+        player.teleport(target);
         this.noticeService.create()
             .player(player.getUniqueId())
             .notice(translation -> translation.teleport().teleportedToRandomPlayer())

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -3,21 +3,20 @@ package com.eternalcode.core.feature.teleport.command;
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
 import com.eternalcode.core.configuration.implementation.PluginConfiguration;
 import com.eternalcode.core.notice.NoticeService;
+import com.eternalcode.core.util.RandomUtil;
 import dev.rollczi.litecommands.command.execute.Execute;
 import dev.rollczi.litecommands.command.permission.Permission;
 import dev.rollczi.litecommands.command.route.Route;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+import panda.std.Option;
 
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
-@Route(name = "teleport-to-random-player", aliases = {"tprp"})
+@Route(name = "teleportorandomplayer", aliases = { "tprp" })
 @Permission("eternalcore.tprp")
 public class TeleportToRandomPlayerCommand {
-
-    private static final Random RANDOM = new Random();
 
     private final Server server;
     private final PluginConfiguration pluginConfiguration;
@@ -29,14 +28,17 @@ public class TeleportToRandomPlayerCommand {
         this.noticeService = noticeService;
     }
 
+
     @Execute
-    @DescriptionDocs(description = "Teleport to random player on server, with filter op players option")
+    @DescriptionDocs(description = "Teleport to a random player on the server, with the option to filter op players")
     void execute(Player player) {
         List<Player> possibleTargetPlayers = this.server.getOnlinePlayers().stream()
             .filter(target -> this.pluginConfiguration.teleport.includeOpPlayersInRandomTeleport || !target.isOp())
             .collect(Collectors.toList());
 
-        if (possibleTargetPlayers.isEmpty()) {
+        Option<Player> randomPlayerOption = RandomUtil.randomElement(possibleTargetPlayers);
+
+        if (randomPlayerOption.isEmpty()) {
             this.noticeService.create()
                 .player(player.getUniqueId())
                 .notice(translation -> translation.teleport().noPlayerToRandomTeleportFound())
@@ -44,7 +46,7 @@ public class TeleportToRandomPlayerCommand {
             return;
         }
 
-        Player randomPlayer = possibleTargetPlayers.get(RANDOM.nextInt(possibleTargetPlayers.size()));
+        Player randomPlayer = randomPlayerOption.get();
 
         player.teleport(randomPlayer);
         this.noticeService.create()

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportToRandomPlayerCommand.java
@@ -41,7 +41,7 @@ public class TeleportToRandomPlayerCommand {
         if (randomPlayerOption.isEmpty()) {
             this.noticeService.create()
                 .player(player.getUniqueId())
-                .notice(translation -> translation.teleport().noPlayerToRandomTeleportFound())
+                .notice(translation -> translation.teleport().randomPlayerNotFound())
                 .send();
             return;
         }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -88,7 +88,7 @@ public interface Translation {
         Notice lastLocationNoExist();
 
         // teleport to random player command
-        Notice noPlayerToRandomTeleportFound();
+        Notice randomPlayerNotFound();
         Notice teleportedToRandomPlayer();
     }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -86,6 +86,10 @@ public interface Translation {
         Notice teleportedToLastLocation();
         Notice teleportedSpecifiedPlayerLastLocation();
         Notice lastLocationNoExist();
+
+        // teleport to random player command
+        Notice noPlayerToRandomTeleportFound();
+        Notice teleportedToRandomPlayer();
     }
 
     // Random Teleport Section

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -209,6 +209,11 @@ public class ENTranslation extends AbstractTranslation {
         public Notice teleportedSpecifiedPlayerLastLocation = Notice.chat("<green>► <white>Teleported <green>{PLAYER} <white>to the last location!");
         @Description(" ")
         public Notice lastLocationNoExist = Notice.chat("<red>✘ <dark_red>Last location is not exist!");
+
+        @Description(" ")
+        public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>No player found to teleport!");
+        @Description({ " ", "# {PLAYER} - Player to whom he was teleported" })
+        public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Teleported to random player <green>{PLAYER}<white>!");
     }
 
     @Description({

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -211,7 +211,7 @@ public class ENTranslation extends AbstractTranslation {
         public Notice lastLocationNoExist = Notice.chat("<red>✘ <dark_red>Last location is not exist!");
 
         @Description(" ")
-        public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>No player found to teleport!");
+        public Notice randomPlayerNotFound = Notice.chat("<red>✘ <dark_red>No player found to teleport!");
         @Description({ " ", "# {PLAYER} - The player you were teleported" })
         public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Teleported to random player <green>{PLAYER}<white>!");
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -212,7 +212,7 @@ public class ENTranslation extends AbstractTranslation {
 
         @Description(" ")
         public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>No player found to teleport!");
-        @Description({ " ", "# {PLAYER} - Player to whom he was teleported" })
+        @Description({ " ", "# {PLAYER} - The player you were teleported" })
         public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Teleported to random player <green>{PLAYER}<white>!");
     }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -211,7 +211,7 @@ public class PLTranslation extends AbstractTranslation {
         public Notice lastLocationNoExist = Notice.chat("<red>✘ <dark_red>Nie ma zapisanej ostatniej lokalizacji!");
 
         @Description(" ")
-        public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>Nie można odnaleźć gracza do teleportacji!");
+        public Notice randomPlayerNotFound = Notice.chat("<red>✘ <dark_red>Nie można odnaleźć gracza do teleportacji!");
         @Description({ " ", "# {PLAYER} - Gracz do którego cię teleportowano" })
         public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Zostałeś losowo teleportowany do <green>{PLAYER}<white>!");
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -212,7 +212,7 @@ public class PLTranslation extends AbstractTranslation {
 
         @Description(" ")
         public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>Nie można odnaleźć gracza do teleportacji!");
-        @Description({ " ", "# {PLAYER} - Player to whom he was teleported" })
+        @Description({ " ", "# {PLAYER} - Gracz do którego cię teleportowano" })
         public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Zostałeś losowo teleportowany do <green>{PLAYER}<white>!");
     }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -209,6 +209,11 @@ public class PLTranslation extends AbstractTranslation {
         public Notice teleportedSpecifiedPlayerLastLocation = Notice.chat("<green>► <white>Przeteleportowano gracza <green>{PLAYER} <white>do ostatniej lokalizacji!");
         @Description(" ")
         public Notice lastLocationNoExist = Notice.chat("<red>✘ <dark_red>Nie ma zapisanej ostatniej lokalizacji!");
+
+        @Description(" ")
+        public Notice noPlayerToRandomTeleportFound = Notice.chat("<red>✘ <dark_red>Nie można odnaleźć gracza do teleportacji!");
+        @Description({ " ", "# {PLAYER} - Player to whom he was teleported" })
+        public Notice teleportedToRandomPlayer = Notice.chat("<green>► <white>Zostałeś losowo teleportowany do <green>{PLAYER}<white>!");
     }
 
     @Description({


### PR DESCRIPTION
This pr adding `/teleport-to-random-player` command (alias: /tprp) including new option in configuration.

This command help admins of servers to spy players, command has option to disable random teleport to player with operator level.

Resolve: #541 issue.