### PR TITLE
GH-550 Prevent vanished players being marked as AFK

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkTask.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkTask.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.feature.afk;
 
+import com.eternalcode.core.feature.vanish.VanishService;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Task;
 import java.util.concurrent.TimeUnit;
@@ -12,11 +13,13 @@ import java.util.UUID;
 class AfkTask implements Runnable {
 
     private final AfkService afkService;
+    private final VanishService vanishService;
     private final Server server;
 
     @Inject
-    public AfkTask(AfkService afkService, Server server) {
+    public AfkTask(AfkService afkService, VanishService vanishService, Server server) {
         this.afkService = afkService;
+        this.vanishService = vanishService;
         this.server = server;
     }
 
@@ -29,7 +32,7 @@ class AfkTask implements Runnable {
         for (Player player : this.server.getOnlinePlayers()) {
             UUID playerUuid = player.getUniqueId();
 
-            if (this.afkService.isAfk(playerUuid)) {
+            if (this.afkService.isAfk(playerUuid) || this.vanishService.isVanished(playerUuid)) {
                 continue;
             }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
@@ -2,7 +2,6 @@ package com.eternalcode.core.feature.vanish;
 
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Service;
-import java.util.Optional;
 import java.util.UUID;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
@@ -20,16 +19,19 @@ public class VanishService {
     }
 
     public boolean isVanished(UUID playerUniqueId) {
-        return Optional.ofNullable(this.server.getPlayer(playerUniqueId))
-            .map(this::isVanished)
-            .orElse(false);
+        Player player = this.server.getPlayer(playerUniqueId);
+        if (player == null) {
+            return false;
+        }
+        return this.isVanished(player);
     }
 
     private boolean isVanished(Player player) {
-        boolean vanished = false;
-        for (MetadataValue value : player.getMetadata(METADATA_VANISHED_KEY)) {
-            vanished |= value.asBoolean();
+        for (MetadataValue isVanished : player.getMetadata(METADATA_VANISHED_KEY)) {
+            if (isVanished.asBoolean()) {
+                return true;
+            }
         }
-        return vanished;
+        return false;
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
@@ -1,0 +1,35 @@
+package com.eternalcode.core.feature.vanish;
+
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.injector.annotations.component.Service;
+import java.util.Optional;
+import java.util.UUID;
+import org.bukkit.Server;
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
+
+@Service
+public class VanishService {
+
+    private static final String METADATA_VANISHED_KEY = "vanished";
+    private final Server server;
+
+    @Inject
+    public VanishService(Server server) {
+        this.server = server;
+    }
+
+    public boolean isVanished(UUID playerUniqueId) {
+        return Optional.ofNullable(this.server.getPlayer(playerUniqueId))
+            .map(this::isVanished)
+            .orElse(false);
+    }
+
+    private boolean isVanished(Player player) {
+        boolean vanished = false;
+        for (MetadataValue value : player.getMetadata(METADATA_VANISHED_KEY)) {
+            vanished |= value.asBoolean();
+        }
+        return vanished;
+    }
+}


### PR DESCRIPTION
## Description

Prevent vanished players being marked as AFK. 

## Note

It should work with most of the plugins for vanish functionality, as it is being resolved with use of commonly established standard. I have tested the plugin with use of SuperVanish and it seems to work fine.