### PR TITLE
GH-751 Fix enchantment argument resolver

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/EnchantmentArgument.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/EnchantmentArgument.java
@@ -10,6 +10,7 @@ import dev.rollczi.litecommands.argument.parser.ParseResult;
 import dev.rollczi.litecommands.invocation.Invocation;
 import dev.rollczi.litecommands.suggestion.SuggestionContext;
 import dev.rollczi.litecommands.suggestion.SuggestionResult;
+import java.util.Locale;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
@@ -26,7 +27,7 @@ class EnchantmentArgument extends AbstractViewerArgument<Enchantment> {
 
     @Override
     public ParseResult<Enchantment> parse(Invocation<CommandSender> invocation, String argument, Translation translation) {
-        Enchantment enchantment = Enchantment.getByKey(NamespacedKey.minecraft(argument));
+        Enchantment enchantment = Enchantment.getByKey(NamespacedKey.minecraft(argument.toLowerCase(Locale.ROOT)));
 
         if (enchantment == null) {
             return ParseResult.failure(translation.argument().noEnchantment());


### PR DESCRIPTION
## Description

Use conversion to lowercase of argument in enchantment resolver to prevent an exception caused due to not matching to namespaced key's pattern.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
