### PR TITLE
GH-789 Fix ChatRestrictEvent sync usage.

### DIFF
--- a/eternalcore-api/src/main/java/com/eternalcode/core/feature/chat/event/restrict/ChatRestrictEvent.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/feature/chat/event/restrict/ChatRestrictEvent.java
@@ -17,7 +17,7 @@ public class ChatRestrictEvent extends Event implements Cancellable {
     private boolean cancelled;
 
     public ChatRestrictEvent(UUID playerUniqueId, ChatRestrictCause chatRestrictCause) {
-        super(false);
+        super(true);
         this.playerUniqueId = playerUniqueId;
         this.chatRestrictCause = chatRestrictCause;
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/EternalCoreEnvironment.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/EternalCoreEnvironment.java
@@ -26,7 +26,7 @@ class EternalCoreEnvironment {
         Environment environment = PaperLib.getEnvironment();
 
         if (!environment.isSpigot()) {
-            this.logger.warning("Your server is running on unsupported software, please use Spigot/Paper or their other 1.20+ forks");
+            this.logger.warning("Your server running on unsupported software, please use Spigot/Paper or their other 1.20+ forks");
             this.logger.warning("We recommend using Paper, download it from https://papermc.io/downloads");
             this.logger.warning("WARNING: Supported Minecraft versions are 1.17-1.20x");
             return;
@@ -37,7 +37,7 @@ class EternalCoreEnvironment {
             return;
         }
 
-        this.logger.info("Your server is running on supported software. Congratulations!");
+        this.logger.info("Your server running on supported software, congratulations!");
         this.logger.info("Server version: " + environment.getMinecraftVersion());
     }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/EternalCoreEnvironment.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/EternalCoreEnvironment.java
@@ -26,7 +26,7 @@ class EternalCoreEnvironment {
         Environment environment = PaperLib.getEnvironment();
 
         if (!environment.isSpigot()) {
-            this.logger.warning("Your server running on unsupported software, please use Spigot/Paper or their other 1.20+ forks");
+            this.logger.warning("Your server is running on unsupported software, please use Spigot/Paper or their other 1.20+ forks");
             this.logger.warning("We recommend using Paper, download it from https://papermc.io/downloads");
             this.logger.warning("WARNING: Supported Minecraft versions are 1.17-1.20x");
             return;
@@ -37,7 +37,7 @@ class EternalCoreEnvironment {
             return;
         }
 
-        this.logger.info("Your server running on supported software, congratulations!");
+        this.logger.info("Your server is running on supported software. Congratulations!");
         this.logger.info("Server version: " + environment.getMinecraftVersion());
     }
 


### PR DESCRIPTION
## Description

Fixes an exception that occurs when slowmode is enabled (e.g., set to 5 seconds) and a user sends messages quickly enough to get limited.

Full exception: https://mclo.gs/mtjw42C

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Enable slowmode using `/chat slowmode 5s`
- Spam
- The user gets notified to slow down, and other players don't see the message.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added test to cover my changes
- [ ] I have added appropriate labels to this Pull Request
