### PR TITLE
GH-791 Fix incompatibility with LibertyBans (and possibly other plugins) by relocate caffeine.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -38,6 +38,8 @@ object Versions {
     const val BSTATS = "3.0.2"
     const val PIXEL_WIDTH = "1.1.0"
 
+    const val CAFFEINE = "3.1.8"
+
     // tests
     const val EXPRESSIBLE_JUNIT = "1.3.6"
     const val GROOVY_ALL = "3.0.21"

--- a/eternalcore-core/build.gradle.kts
+++ b/eternalcore-core/build.gradle.kts
@@ -93,4 +93,8 @@ eternalShadow {
     // metrics
     library("org.bstats:bstats-bukkit:${Versions.BSTATS}")
     libraryRelocate("org.bstats")
+
+    // caffeine
+    library("com.github.ben-manes.caffeine:caffeine:${Versions.CAFFEINE}")
+    libraryRelocate("com.github.benmanes.caffeine");
 }

--- a/eternalcore-docs-generate/build.gradle.kts
+++ b/eternalcore-docs-generate/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly("commons-io:commons-io:${Versions.APACHE_COMMONS}")
     runtimeOnly("dev.triumphteam:triumph-gui:${Versions.TRIUMPH_GUI}")
     runtimeOnly("org.bstats:bstats-bukkit:${Versions.BSTATS}")
+    runtimeOnly("com.github.ben-manes.caffeine:caffeine:${Versions.CAFFEINE}")
     runtimeOnly("com.eternalcode:multification-core:${Versions.MULTIFICATION}")
     runtimeOnly("com.eternalcode:eternalcode-commons-bukkit:${Versions.ETERNALCODE_COMMONS}")
     runtimeOnly("com.eternalcode:eternalcode-commons-adventure:${Versions.ETERNALCODE_COMMONS}")


### PR DESCRIPTION
## Description

Add caffeine as a library, and relocate it.

Fixes incompatibility with LibertyBans (and possibly other plugins).

More info [in the discord server](https://discord.com/channels/889460117953720351/1025826334435455047/1249739215936426125)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Didn't test yet, I'm committing from a chromebook.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have added test to cover my changes
- [ ] I have added appropriate labels to this Pull Request

