### PR TITLE
GH-790 Fix duration format

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -7,23 +7,28 @@ import java.time.temporal.ChronoUnit;
 
 public class DurationUtil {
 
-    private static final TemporalAmountParser<Duration> WITHOUT_MILLS = new DurationParser()
+    private static final TemporalAmountParser<Duration> WITHOUT_MILLS_FORMAT = new DurationParser()
         .withUnit("s", ChronoUnit.SECONDS)
         .withUnit("m", ChronoUnit.MINUTES)
         .withUnit("h", ChronoUnit.HOURS)
         .withUnit("d", ChronoUnit.DAYS)
         .roundOff(ChronoUnit.MILLIS);
 
+    private static final TemporalAmountParser<Duration> STANDARD_FORMAT = new DurationParser()
+        .withUnit("s", ChronoUnit.SECONDS)
+        .withUnit("m", ChronoUnit.MINUTES)
+        .withUnit("h", ChronoUnit.HOURS)
+        .withUnit("d", ChronoUnit.DAYS);
+
     public DurationUtil() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }
 
-
-    public static String format(Duration duration) {
-        if (duration.toMillis() < 1000) {
-            return "0s";
+    public static String format(Duration duration, boolean removeMills) {
+        if (removeMills) {
+            return WITHOUT_MILLS_FORMAT.format(duration);
         }
 
-        return WITHOUT_MILLS.format(duration);
+        return STANDARD_FORMAT.format(duration);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -18,7 +18,12 @@ public class DurationUtil {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }
 
+
     public static String format(Duration duration) {
+        if (duration.toMillis() < 1000) {
+            return "0s";
+        }
+
         return WITHOUT_MILLS.format(duration);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -29,7 +29,7 @@ public class DurationUtil {
 
     public static String format(Duration duration, boolean removeMills) {
         if (removeMills) {
-            return WITHOUT_MILLS_FORMAT.format(duration);
+            return WITHOUT_MILLIS_FORMAT.format(duration);
         }
 
         if (duration.toMillis() < ONE_SECOND.toMillis()) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -36,7 +36,7 @@ public class DurationUtil {
             return STANDARD_FORMAT.format(duration);
         }
 
-        return WITHOUT_MILLS_FORMAT.format(duration);
+        return WITHOUT_MILLIS_FORMAT.format(duration);
     }
 
     public static String format(Duration duration) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -21,6 +21,8 @@ public class DurationUtil {
         .withUnit("s", ChronoUnit.SECONDS)
         .withUnit("ms", ChronoUnit.MILLIS);
 
+    public static final Duration ONE_SECOND = Duration.ofSeconds(1);
+
     public DurationUtil() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }
@@ -30,7 +32,7 @@ public class DurationUtil {
             return WITHOUT_MILLS_FORMAT.format(duration);
         }
 
-        if (duration.toMillis() < Duration.ofSeconds(1).toMillis()) {
+        if (duration.toMillis() < ONE_SECOND.toMillis()) {
             return STANDARD_FORMAT.format(duration);
         }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -15,10 +15,11 @@ public class DurationUtil {
         .roundOff(ChronoUnit.MILLIS);
 
     private static final TemporalAmountParser<Duration> STANDARD_FORMAT = new DurationParser()
-        .withUnit("s", ChronoUnit.SECONDS)
-        .withUnit("m", ChronoUnit.MINUTES)
+        .withUnit("d", ChronoUnit.DAYS)
         .withUnit("h", ChronoUnit.HOURS)
-        .withUnit("d", ChronoUnit.DAYS);
+        .withUnit("m", ChronoUnit.MINUTES)
+        .withUnit("s", ChronoUnit.SECONDS)
+        .withUnit("ms", ChronoUnit.MILLIS);
 
     public DurationUtil() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
@@ -29,7 +30,11 @@ public class DurationUtil {
             return WITHOUT_MILLS_FORMAT.format(duration);
         }
 
-        return STANDARD_FORMAT.format(duration);
+        if (duration.toMillis() < Duration.ofSeconds(1).toMillis()) {
+            return STANDARD_FORMAT.format(duration);
+        }
+
+        return WITHOUT_MILLS_FORMAT.format(duration);
     }
 
     public static String format(Duration duration) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -28,7 +28,7 @@ public class DurationUtil {
     }
 
     public static String format(Duration duration, boolean removeMillis) {
-        if (removeMills) {
+        if (removeMillis) {
             return WITHOUT_MILLIS_FORMAT.format(duration);
         }
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -31,4 +31,8 @@ public class DurationUtil {
 
         return STANDARD_FORMAT.format(duration);
     }
+
+    public static String format(Duration duration) {
+        return format(duration, false);
+    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -7,7 +7,7 @@ import java.time.temporal.ChronoUnit;
 
 public class DurationUtil {
 
-    private static final TemporalAmountParser<Duration> WITHOUT_MILLS_FORMAT = new DurationParser()
+    private static final TemporalAmountParser<Duration> WITHOUT_MILLIS_FORMAT = new DurationParser()
         .withUnit("s", ChronoUnit.SECONDS)
         .withUnit("m", ChronoUnit.MINUTES)
         .withUnit("h", ChronoUnit.HOURS)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/util/DurationUtil.java
@@ -27,7 +27,7 @@ public class DurationUtil {
         throw new UnsupportedOperationException("This class cannot be instantiated");
     }
 
-    public static String format(Duration duration, boolean removeMills) {
+    public static String format(Duration duration, boolean removeMillis) {
         if (removeMills) {
             return WITHOUT_MILLIS_FORMAT.format(duration);
         }


### PR DESCRIPTION
Fixes: #790. This is currently the only solution that satisfies me.

The idea is that the format should return a single member of the format "1s" but also take into account the milli-seconds at a later time, so that the format does not return empty text.


![image](https://github.com/EternalCodeTeam/EternalCore/assets/65517973/9ad7178f-2b32-4d58-a9d4-e19c822411b7)
