### PR TITLE
GH-859 Add `%eternalcore_afk_formatted%` placeholder.

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
@@ -29,7 +29,7 @@ class AftPlaceholderSetup implements Subscriber {
             "afk",
             player -> String.valueOf(afkService.isAfk(player.getUniqueId()))));
         placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of(
-            "afk_text",
+            "afk_formatted",
             player -> {
                 Translation messages = this.translationManager.getMessages(this.viewerService.player(player.getUniqueId()));
                 return afkService.isAfk(player.getUniqueId()) ?

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
@@ -1,18 +1,39 @@
 package com.eternalcode.core.feature.afk;
 
+import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Controller;
 import com.eternalcode.core.publish.Subscriber;
 import com.eternalcode.core.publish.event.EternalInitializeEvent;
 import com.eternalcode.core.placeholder.PlaceholderRegistry;
 import com.eternalcode.core.placeholder.PlaceholderReplacer;
 import com.eternalcode.core.publish.Subscribe;
+import com.eternalcode.core.translation.Translation;
+import com.eternalcode.core.translation.TranslationManager;
+import com.eternalcode.core.viewer.ViewerService;
 
 @Controller
 class AftPlaceholderSetup implements Subscriber {
 
-    @Subscribe(EternalInitializeEvent.class)
-    void setUpPlaceholders(PlaceholderRegistry placeholderRegistry, AfkService afkService) {
-        placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of("afk", player -> String.valueOf(afkService.isAfk(player.getUniqueId()))));
+    private final TranslationManager translationManager;
+    private final ViewerService viewerService;
+
+    @Inject
+    AftPlaceholderSetup(TranslationManager translationManager, ViewerService viewerService) {
+        this.translationManager = translationManager;
+        this.viewerService = viewerService;
     }
 
+    @Subscribe(EternalInitializeEvent.class)
+    void setUpPlaceholders(PlaceholderRegistry placeholderRegistry, AfkService afkService) {
+        placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of(
+            "afk",
+            player -> String.valueOf(afkService.isAfk(player.getUniqueId()))));
+        placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of(
+            "afk_text",
+            player -> {
+                Translation messages = this.translationManager.getMessages(this.viewerService.player(player.getUniqueId()));
+                return afkService.isAfk(player.getUniqueId()) ?
+                    messages.afk().afkEnabledPlaceholder() : messages.afk().afkDisabledPlaceholder();
+            }));
+    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -258,6 +258,9 @@ public interface Translation {
         Notice afkOff();
         Notice afkDelay();
         String afkKickReason();
+
+        String afkEnabledPlaceholder();
+        String afkDisabledPlaceholder();
     }
 
     // event section

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -505,6 +505,7 @@ public class ENTranslation extends AbstractTranslation {
         @Description({ " " })
         public String afkKickReason = "<red>You have been kicked due to inactivity!";
 
+        @Description({" ", "# Placeholder used in %eternalcore_afk_formatted% to indicate AFK status"})
         public String afkEnabledPlaceholder = "<red><b>AFK";
         public String afkDisabledPlaceholder = "";
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -504,6 +504,9 @@ public class ENTranslation extends AbstractTranslation {
 
         @Description({ " " })
         public String afkKickReason = "<red>You have been kicked due to inactivity!";
+
+        public String afkEnabledPlaceholder = "<red><b>AFK";
+        public String afkDisabledPlaceholder = "";
     }
 
     @Description({

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -512,6 +512,7 @@ public class PLTranslation extends AbstractTranslation {
         @Description({ " " })
         public String afkKickReason = "<red>Zostałeś wyrzucone z powodu braku aktywności!";
 
+        @Description({" ", "# Używane w %eternalcore_afk_formatted% do wskazania statusu AFK"})
         public String afkEnabledPlaceholder = "<red><b>AFK";
         public String afkDisabledPlaceholder = "";
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -511,6 +511,9 @@ public class PLTranslation extends AbstractTranslation {
 
         @Description({ " " })
         public String afkKickReason = "<red>Zostałeś wyrzucone z powodu braku aktywności!";
+
+        public String afkEnabledPlaceholder = "<red><b>AFK";
+        public String afkDisabledPlaceholder = "";
     }
 
     @Description({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new AFK status placeholders for both English and Polish translations.
	- Enhanced messaging capabilities related to player status, including new messages for inactivity and player deaths.
	- Added support for retrieving AFK status messages through new translation methods.

- **Bug Fixes**
	- Improved clarity and functionality in placeholder registration for AFK status.

- **Documentation**
	- Updated translation interfaces to include new methods for AFK status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->