### PR TITLE
GH-863 Add afk time placeholder.

### DIFF
--- a/eternalcore-api/src/main/java/com/eternalcode/core/feature/afk/AfkService.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/feature/afk/AfkService.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.feature.afk;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -53,5 +54,5 @@ public interface AfkService {
      * @param playerUniqueId Unique identifier of the player.
      * @return Afk object representing player's AFK status.
      */
-    Afk getAfk(UUID playerUniqueId);
+    Optional<Afk> getAfk(UUID playerUniqueId);
 }

--- a/eternalcore-api/src/main/java/com/eternalcode/core/feature/afk/AfkService.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/feature/afk/AfkService.java
@@ -46,4 +46,12 @@ public interface AfkService {
      * @return Created an Afk object representing player's AFK status.
      */
     Afk markAfk(UUID playerUniqueId, AfkReason reason);
+
+    /**
+     * Gets the AFK status of a uniqueId.
+     *
+     * @param playerUniqueId Unique identifier of the player.
+     * @return Afk object representing player's AFK status.
+     */
+    Afk getAfk(UUID playerUniqueId);
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkServiceImpl.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkServiceImpl.java
@@ -60,6 +60,10 @@ class AfkServiceImpl implements AfkService {
         return afk;
     }
 
+    @Override
+    public Afk getAfk(UUID playerUniqueId) {
+        return this.afkByPlayer.get(playerUniqueId);
+    }
 
     @Override
     public void markInteraction(UUID playerUniqueId) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkServiceImpl.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkServiceImpl.java
@@ -7,6 +7,7 @@ import com.eternalcode.core.injector.annotations.component.Service;
 import com.eternalcode.core.notice.NoticeService;
 import com.eternalcode.core.user.User;
 import com.eternalcode.core.user.UserManager;
+import java.util.Optional;
 import org.jetbrains.annotations.ApiStatus;
 
 import java.time.Duration;
@@ -61,8 +62,8 @@ class AfkServiceImpl implements AfkService {
     }
 
     @Override
-    public Afk getAfk(UUID playerUniqueId) {
-        return this.afkByPlayer.get(playerUniqueId);
+    public Optional<Afk> getAfk(UUID playerUniqueId) {
+        return Optional.ofNullable(this.afkByPlayer.get(playerUniqueId));
     }
 
     @Override

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
@@ -13,6 +13,7 @@ import com.eternalcode.core.util.DurationUtil;
 import com.eternalcode.core.viewer.ViewerService;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 
 @Controller
 class AftPlaceholderSetup implements Subscriber {
@@ -42,12 +43,12 @@ class AftPlaceholderSetup implements Subscriber {
         placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of(
             "afk_time",
             player -> {
-                Afk afk = afkService.getAfk(player.getUniqueId());
-
-                if (afk == null) {
+                Optional<Afk> afkOptional = afkService.getAfk(player.getUniqueId());
+                if (afkOptional.isEmpty()) {
                     return "";
                 }
 
+                Afk afk = afkOptional.get();
                 Instant start = afk.getStart();
                 Instant now = Instant.now();
                 Duration afkDuration = Duration.between(start, now);

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AftPlaceholderSetup.java
@@ -2,14 +2,17 @@ package com.eternalcode.core.feature.afk;
 
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Controller;
-import com.eternalcode.core.publish.Subscriber;
-import com.eternalcode.core.publish.event.EternalInitializeEvent;
 import com.eternalcode.core.placeholder.PlaceholderRegistry;
 import com.eternalcode.core.placeholder.PlaceholderReplacer;
 import com.eternalcode.core.publish.Subscribe;
+import com.eternalcode.core.publish.Subscriber;
+import com.eternalcode.core.publish.event.EternalInitializeEvent;
 import com.eternalcode.core.translation.Translation;
 import com.eternalcode.core.translation.TranslationManager;
+import com.eternalcode.core.util.DurationUtil;
 import com.eternalcode.core.viewer.ViewerService;
+import java.time.Duration;
+import java.time.Instant;
 
 @Controller
 class AftPlaceholderSetup implements Subscriber {
@@ -34,6 +37,21 @@ class AftPlaceholderSetup implements Subscriber {
                 Translation messages = this.translationManager.getMessages(this.viewerService.player(player.getUniqueId()));
                 return afkService.isAfk(player.getUniqueId()) ?
                     messages.afk().afkEnabledPlaceholder() : messages.afk().afkDisabledPlaceholder();
+            }));
+
+        placeholderRegistry.registerPlaceholder(PlaceholderReplacer.of(
+            "afk_time",
+            player -> {
+                Afk afk = afkService.getAfk(player.getUniqueId());
+
+                if (afk == null) {
+                    return "";
+                }
+
+                Instant start = afk.getStart();
+                Instant now = Instant.now();
+                Duration afkDuration = Duration.between(start, now);
+                return DurationUtil.format(afkDuration, true);
             }));
     }
 }


### PR DESCRIPTION
Fixes: #863 

![image](https://github.com/user-attachments/assets/d6eb921e-1c9f-4c58-ac3c-771ef38a7f32) -> `papi parse vlucky_dev %eternalcore_afk_time%`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to retrieve a player's AFK status using their unique ID.
	- Added a placeholder for displaying AFK duration in the system.

- **Bug Fixes**
	- Enhanced the functionality of the AFK service without altering existing methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->