### PR TITLE
GH-878 Add vanish permission check for player tab suggestions

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
@@ -50,9 +50,10 @@ public class PlayerArgument extends AbstractViewerArgument<Player> {
         Argument<Player> argument,
         SuggestionContext context
     ) {
+        CommandSender sender = invocation.sender();
         return this.server.getOnlinePlayers().stream()
-            .filter(player -> !this.vanishService.isVanished(player.getUniqueId()))
-            .map(player -> player.getName())
+            .filter(player -> this.vanishService.canSeeVanished(sender) || !this.vanishService.isVanished(player.getUniqueId()))
+            .map(Player::getName)
             .collect(SuggestionResult.collector());
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
@@ -1,6 +1,7 @@
 package com.eternalcode.core.bridge.litecommand.argument;
 
 import com.eternalcode.annotations.scan.feature.FeatureDocs;
+import com.eternalcode.core.feature.vanish.VanishPermissionConstant;
 import com.eternalcode.core.feature.vanish.VanishService;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.lite.LiteArgument;
@@ -48,7 +49,7 @@ public class PlayerArgument extends AbstractViewerArgument<Player> {
     @FeatureDocs(
         name = "Vanish tabulation",
         description = "EternalCore prevents non-admin players from seeing vanished players in the commands like /tpa."
-            + " To re-enable this feature for specific players, grant them the eternalcore.vanish.see permission."
+            + " To re-enable this feature for specific players, grant them the eternalcore.vanish.tabulation.see permission."
     )
     @Override
     public SuggestionResult suggest(
@@ -58,8 +59,12 @@ public class PlayerArgument extends AbstractViewerArgument<Player> {
     ) {
         CommandSender sender = invocation.sender();
         return this.server.getOnlinePlayers().stream()
-            .filter(player -> this.vanishService.canSeeVanished(sender) || !this.vanishService.isVanished(player.getUniqueId()))
+            .filter(player -> this.canSeeVanished(sender) || !this.vanishService.isVanished(player.getUniqueId()))
             .map(Player::getName)
             .collect(SuggestionResult.collector());
+    }
+
+    public boolean canSeeVanished(CommandSender sender) {
+        return sender.hasPermission(VanishPermissionConstant.VANISH_SEE_TABULATION_PERMISSION);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/bridge/litecommand/argument/PlayerArgument.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.bridge.litecommand.argument;
 
+import com.eternalcode.annotations.scan.feature.FeatureDocs;
 import com.eternalcode.core.feature.vanish.VanishService;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.lite.LiteArgument;
@@ -44,6 +45,11 @@ public class PlayerArgument extends AbstractViewerArgument<Player> {
         return ParseResult.success(target);
     }
 
+    @FeatureDocs(
+        name = "Vanish tabulation",
+        description = "EternalCore prevents non-admin players from seeing vanished players in the commands like /tpa."
+            + " To re-enable this feature for specific players, grant them the eternalcore.vanish.see permission."
+    )
     @Override
     public SuggestionResult suggest(
         Invocation<CommandSender> invocation,

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishPermissionConstant.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishPermissionConstant.java
@@ -1,6 +1,6 @@
 package com.eternalcode.core.feature.vanish;
 
-class VanishPermissionConstant {
+public class VanishPermissionConstant {
 
-    static final String VANISH_SEE_PERMISSION = "eternalcore.vanish.see";
+    public static final String VANISH_SEE_TABULATION_PERMISSION = "eternalcore.vanish.tabulation.see";
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishPermissionConstant.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishPermissionConstant.java
@@ -1,0 +1,6 @@
+package com.eternalcode.core.feature.vanish;
+
+class VanishPermissionConstant {
+
+    static final String VANISH_SEE_PERMISSION = "eternalcore.vanish.see";
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
@@ -1,6 +1,5 @@
 package com.eternalcode.core.feature.vanish;
 
-import com.eternalcode.annotations.scan.feature.FeatureDocs;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Service;
 import java.util.UUID;
@@ -35,9 +34,5 @@ public class VanishService {
             }
         }
         return false;
-    }
-
-    public boolean canSeeVanished(CommandSender sender) {
-        return sender.hasPermission(VanishPermissionConstant.VANISH_SEE_PERMISSION);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
@@ -1,9 +1,11 @@
 package com.eternalcode.core.feature.vanish;
 
+import com.eternalcode.annotations.scan.feature.FeatureDocs;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Service;
 import java.util.UUID;
 import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.MetadataValue;
 
@@ -33,5 +35,14 @@ public class VanishService {
             }
         }
         return false;
+    }
+
+    @FeatureDocs(
+        name = "Vanish tabulation",
+        description = "EternalCore prevents non-admin players from seeing vanished players in the commands like /tpa."
+            + " To re-enable this feature for specific players, grant them the eternalcore.vanish.see permission."
+    )
+    public boolean canSeeVanished(CommandSender sender) {
+        return sender.hasPermission(VanishPermissionConstant.VANISH_SEE_PERMISSION);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/vanish/VanishService.java
@@ -37,11 +37,6 @@ public class VanishService {
         return false;
     }
 
-    @FeatureDocs(
-        name = "Vanish tabulation",
-        description = "EternalCore prevents non-admin players from seeing vanished players in the commands like /tpa."
-            + " To re-enable this feature for specific players, grant them the eternalcore.vanish.see permission."
-    )
     public boolean canSeeVanished(CommandSender sender) {
         return sender.hasPermission(VanishPermissionConstant.VANISH_SEE_PERMISSION);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced player suggestion logic to account for visibility of vanished players.
	- Introduced a new permission constant for the vanish feature.
	- Added a method to check if a user can see vanished players.

- **Documentation**
	- Added documentation for the "Vanish tabulation" feature and updated related method documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->