### PR TITLE
GH-905 Add server links feature to pause menu (1.21+ only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Get the latest development builds from our [GitHub Actions](https://github.com/E
 - :house: Home, Warp, and Spawn System
 - :page_facing_up: PlaceholderAPI Support
 - :memo: Customizable and Translatable Messages (Player language selection available)
+- <details><summary>Server links feature (Click to see how it's works)</summary><img src="assets/server-links-showcase.gif" alt="Video Guide"></details>
 - :gear: Advanced Configuration System for customization
 - :card_index: Database Integration (PostgreSQL, SQLite, MySQL, MariaDB, H2)
 - :rainbow: Adventure and [MiniMessage](https://docs.advntr.dev/minimessage/format.html) integration with legacy color processing (e.g., &7, &e)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -9,6 +9,7 @@ import com.eternalcode.core.feature.chat.ChatSettings;
 import com.eternalcode.core.feature.helpop.HelpOpSettings;
 import com.eternalcode.core.feature.jail.JailSettings;
 import com.eternalcode.core.feature.randomteleport.RandomTeleportSettingsImpl;
+import com.eternalcode.core.feature.serverlinks.ServerLinksConfig;
 import com.eternalcode.core.feature.spawn.SpawnSettings;
 import com.eternalcode.core.injector.annotations.Bean;
 import com.eternalcode.core.injector.annotations.component.ConfigurationFile;
@@ -439,6 +440,10 @@ public class PluginConfiguration implements ReloadableConfig {
             return this.catboyWalkSpeed;
         }
     }
+
+    @Bean
+    @Description({ " ", "# ServerLinks Section" })
+    ServerLinksConfig serverLinks = new ServerLinksConfig();
 
     @Override
     public Resource resource(File folder) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksConfig.java
@@ -1,0 +1,21 @@
+package com.eternalcode.core.feature.serverlinks;
+
+import java.util.List;
+import net.dzikoysk.cdn.entity.Contextual;
+import net.dzikoysk.cdn.entity.Description;
+
+@Contextual
+public class ServerLinksConfig {
+
+    @Description({
+        "# Configuration of server links displayed in the ESC/pause menu",
+        "# Links will be visible in the game's pause menu under server information",
+        "# Note: This feature requires Minecraft version 1.21 or newer to work properly"
+    })
+    public boolean sendLinksOnJoin = true;
+
+    public List<ServerLinksEntry> serverLinks = List.of(
+        ServerLinksEntry.of("<rainbow>Discord", "https://discord.gg/v2rkPb4Q2r"),
+        ServerLinksEntry.of("Website", "https://www.eternalcode.pl")
+    );
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksController.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksController.java
@@ -1,0 +1,30 @@
+package com.eternalcode.core.feature.serverlinks;
+
+import com.eternalcode.core.compatibility.Compatibility;
+import com.eternalcode.core.compatibility.Version;
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.injector.annotations.component.Controller;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+@Controller
+@Compatibility(from = @Version(minor = 21, patch = 0))
+public class ServerLinksController implements Listener {
+
+    private final ServerLinksService serverLinksService;
+    private final ServerLinksConfig serverLinksConfig;
+
+    @Inject
+    public ServerLinksController(ServerLinksService serverLinksService, ServerLinksConfig serverLinksConfig) {
+        this.serverLinksService = serverLinksService;
+        this.serverLinksConfig = serverLinksConfig;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        if (this.serverLinksConfig.sendLinksOnJoin) {
+            this.serverLinksService.sendServerLinks(event.getPlayer());
+        }
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksEntry.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksEntry.java
@@ -1,0 +1,27 @@
+package com.eternalcode.core.feature.serverlinks;
+
+import net.dzikoysk.cdn.entity.Contextual;
+
+@Contextual
+public class ServerLinksEntry {
+
+    public final String name;
+    public final String address;
+
+    public ServerLinksEntry(String name, String address) {
+        this.name = name;
+        this.address = address;
+    }
+
+    public static ServerLinksEntry of(String name, String address) {
+        return new ServerLinksEntry(name, address);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String address() {
+        return address;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksEntry.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksEntry.java
@@ -22,6 +22,6 @@ public class ServerLinksEntry {
     }
 
     public String address() {
-        return address;
+        return this.address;
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksService.java
@@ -2,6 +2,7 @@ package com.eternalcode.core.feature.serverlinks;
 
 import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
 
+import com.eternalcode.annotations.scan.feature.FeatureDocs;
 import com.eternalcode.core.compatibility.Compatibility;
 import com.eternalcode.core.compatibility.Version;
 import com.eternalcode.core.injector.annotations.Inject;
@@ -16,6 +17,7 @@ import org.bukkit.plugin.Plugin;
 
 @Service
 @Compatibility(from = @Version(minor = 21, patch = 0))
+@FeatureDocs(name = "ServerLinks", description = "Server links to players allow to display link's dedicated to server social media. Displayed under the pause menu (ESC).")
 public class ServerLinksService {
 
     private final Plugin plugin;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/ServerLinksService.java
@@ -1,0 +1,66 @@
+package com.eternalcode.core.feature.serverlinks;
+
+import static net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection;
+
+import com.eternalcode.core.compatibility.Compatibility;
+import com.eternalcode.core.compatibility.Version;
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.injector.annotations.component.Service;
+import java.net.URI;
+import java.net.URISyntaxException;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.ServerLinks;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+@Service
+@Compatibility(from = @Version(minor = 21, patch = 0))
+public class ServerLinksService {
+
+    private final Plugin plugin;
+    private final MiniMessage miniMessage;
+    private final ServerLinksConfig config;
+
+    @Inject
+    public ServerLinksService(Plugin plugin, MiniMessage miniMessage, ServerLinksConfig config) {
+        this.plugin = plugin;
+        this.miniMessage = miniMessage;
+        this.config = config;
+    }
+
+    public void sendServerLinks(Player player) {
+        ServerLinks serverLinks = this.plugin.getServer().getServerLinks().copy();
+
+        for (ServerLinksEntry serverLink : this.config.serverLinks) {
+            this.parseLinks(serverLinks, serverLink);
+        }
+
+        player.sendLinks(serverLinks);
+    }
+
+    private URI parseUrl(String url) {
+        try {
+            if (!url.startsWith("https://") && !url.startsWith("http://")) {
+                return null;
+            }
+            return new URI(url);
+        }
+        catch (URISyntaxException exception) {
+            return null;
+        }
+    }
+
+    private org.bukkit.ServerLinks.ServerLink parseLinks(org.bukkit.ServerLinks serverLinks, ServerLinksEntry links) {
+        URI url = parseUrl(links.address());
+
+        if (url == null) {
+            return null;
+        }
+
+        // TODO: Use ServerLinks#addLinks(Component, URI) instead of ServerLinks#addLink(String, URI) when we use
+        //  PaperAPI in nearly future.
+        Component deserialize = this.miniMessage.deserialize(links.name());
+        return serverLinks.addLink(legacySection().serialize(deserialize), url);
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/package-info.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/package-info.java
@@ -1,0 +1,6 @@
+package com.eternalcode.core.feature.serverlinks;
+
+
+/*
+This feature work's only with Minecraft version 1.21 or newer
+ */

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/package-info.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/serverlinks/package-info.java
@@ -1,6 +1,0 @@
-package com.eternalcode.core.feature.serverlinks;
-
-
-/*
-This feature work's only with Minecraft version 1.21 or newer
- */


### PR DESCRIPTION
**Adds the functionality of customizable server links in the pause menu (ESC).**  
---

### **Compatibility:**
🛠️ **Requires Minecraft 1.21+** - feature uses the new `ServerLinks` API added in version 1.21.  
⚠️ **Does not work on older versions!**

---

### **Demo:**  

https://github.com/user-attachments/assets/78d746b3-80bf-4a8c-82f0-6c3853be0978



*Config:*  
```yaml
# ServerLinks Section
serverLinks:
  # Configuration of server links displayed in the ESC/pause menu
  # Links will be visible in the game's pause menu under server information
  # Note: This feature requires Minecraft version 1.21 or newer to work properly
  sendLinksOnJoin: true
  serverLinks:
    - :
      name: "<rainbow>Discord"
      address: "https://discord.gg/v2rkPb4Q2r"
    - :
      name: "Website"
      address: "https://www.eternalcode.pl"
```