### PR TITLE
GH-909 Resolve auto-message issues with database query, and message ordering.

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageCommand.java
@@ -3,10 +3,10 @@ package com.eternalcode.core.feature.automessage;
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
+import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
-import dev.rollczi.litecommands.annotations.command.Command;
 import org.bukkit.entity.Player;
 
 @Command(name = "automessage", aliases = { "automsg" })

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageRepositoryOrmLite.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageRepositoryOrmLite.java
@@ -5,12 +5,9 @@ import com.eternalcode.core.database.DatabaseManager;
 import com.eternalcode.core.database.wrapper.AbstractRepositoryOrmLite;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Repository;
-import com.j256.ormlite.field.DatabaseField;
 import com.j256.ormlite.stmt.Where;
-import com.j256.ormlite.table.DatabaseTable;
 import com.j256.ormlite.table.TableUtils;
 import java.sql.SQLException;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,7 +21,7 @@ class AutoMessageRepositoryOrmLite extends AbstractRepositoryOrmLite implements 
     @Inject
     private AutoMessageRepositoryOrmLite(DatabaseManager databaseManager, Scheduler scheduler) throws SQLException {
         super(databaseManager, scheduler);
-        TableUtils.createTableIfNotExists(databaseManager.connectionSource(), AutoMessageIgnoreWrapper.class);
+        TableUtils.createTableIfNotExists(databaseManager.connectionSource(), AutoMessageTable.class);
     }
 
     @Override
@@ -33,16 +30,11 @@ class AutoMessageRepositoryOrmLite extends AbstractRepositoryOrmLite implements 
             return CompletableFuture.completedFuture(onlineUniqueIds);
         }
 
-        CompletableFuture<List<AutoMessageIgnoreWrapper>> wrapperList =
-            this.action(AutoMessageIgnoreWrapper.class, dao -> {
-                Where<AutoMessageIgnoreWrapper, Object> where = dao.queryBuilder().where();
-
-                for (UUID onlineUniqueId : onlineUniqueIds) {
-                    where.eq("unique_id", onlineUniqueId);
-                }
-
-                where.or(onlineUniqueIds.size());
-
+        CompletableFuture<List<AutoMessageTable>> wrapperList =
+            this.action(
+                AutoMessageTable.class, dao -> {
+                Where<AutoMessageTable, Object> where = dao.queryBuilder().where();
+                where.in("unique_id", onlineUniqueIds);
                 return where.query();
             });
 
@@ -51,47 +43,27 @@ class AutoMessageRepositoryOrmLite extends AbstractRepositoryOrmLite implements 
                 .map(wrapper -> wrapper.uniqueId)
                 .collect(Collectors.toSet());
 
-            Set<UUID> onlineUniqueIdsWithoutIgnores = new HashSet<>();
-
-            for (UUID onlineUniqueId : onlineUniqueIds) {
-                if (!ignoredIds.contains(onlineUniqueId)) {
-                    onlineUniqueIdsWithoutIgnores.add(onlineUniqueId);
-                }
-            }
-
-            return onlineUniqueIdsWithoutIgnores;
+            return onlineUniqueIds.stream()
+                .filter(onlineUniqueId -> !ignoredIds.contains(onlineUniqueId))
+                .collect(Collectors.toSet());
         });
     }
 
     @Override
     public CompletableFuture<Boolean> isReceiving(UUID uniqueId) {
-        return this.selectSafe(AutoMessageIgnoreWrapper.class, uniqueId).thenApply(Optional::isEmpty);
+        return this.selectSafe(AutoMessageTable.class, uniqueId).thenApply(Optional::isEmpty);
     }
 
     @Override
     public CompletableFuture<Boolean> switchReceiving(UUID uniqueId) {
-        return this.selectSafe(AutoMessageIgnoreWrapper.class, uniqueId).thenCompose(optional -> {
+        return this.selectSafe(AutoMessageTable.class, uniqueId).thenCompose(optional -> {
             if (optional.isEmpty()) {
-                return this.save(AutoMessageIgnoreWrapper.class, new AutoMessageIgnoreWrapper(uniqueId))
+                return this.save(AutoMessageTable.class, new AutoMessageTable(uniqueId))
                     .thenApply(result -> false);
             }
 
-            AutoMessageIgnoreWrapper wrapper = optional.get();
-
-            return this.delete(AutoMessageIgnoreWrapper.class, wrapper).thenApply(state -> true);
+            AutoMessageTable wrapper = optional.get();
+            return this.delete(AutoMessageTable.class, wrapper).thenApply(state -> true);
         });
-    }
-
-    @DatabaseTable(tableName = "eternal_core_auto_message_ignore")
-    private static class AutoMessageIgnoreWrapper {
-
-        @DatabaseField(columnName = "unique_id", id = true)
-        UUID uniqueId;
-
-        AutoMessageIgnoreWrapper() {}
-
-        AutoMessageIgnoreWrapper(UUID uniqueId) {
-            this.uniqueId = uniqueId;
-        }
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageService.java
@@ -1,13 +1,12 @@
 package com.eternalcode.core.feature.automessage;
 
-import com.eternalcode.annotations.scan.feature.FeatureDocs;
 import com.eternalcode.commons.RandomElementUtil;
 import com.eternalcode.commons.scheduler.Scheduler;
 import com.eternalcode.core.configuration.implementation.PluginConfiguration;
+import com.eternalcode.core.feature.automessage.messages.AutoMessageMessages;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.component.Service;
 import com.eternalcode.core.notice.NoticeService;
-import com.eternalcode.core.feature.automessage.messages.AutoMessageMessages;
 import com.eternalcode.multification.notice.Notice;
 import java.util.Collection;
 import java.util.Optional;
@@ -19,7 +18,6 @@ import java.util.stream.Collectors;
 import org.bukkit.Server;
 import org.bukkit.entity.Entity;
 
-@FeatureDocs(name = "AutoMessage", description = "Automatically sends messages to players at a given time interval.")
 @Service
 class AutoMessageService {
 
@@ -55,6 +53,15 @@ class AutoMessageService {
         return this.repository.switchReceiving(uniqueId);
     }
 
+    private void tick() {
+        this.scheduler.timerAsync(
+            () -> {
+                if (this.settings.enabled()) {
+                    this.broadcastNextMessage();
+                }
+            }, this.settings.interval(), this.settings.interval());
+    }
+
     public void broadcastNextMessage() {
         Set<UUID> onlineUniqueIds = this.server.getOnlinePlayers().stream()
             .map(Entity::getUniqueId)
@@ -76,15 +83,6 @@ class AutoMessageService {
                 .send();
         });
     }
-
-    private void tick() {
-        this.scheduler.runLaterAsync(this::tick, this.settings.interval());
-
-        if (this.settings.enabled()) {
-            this.broadcastNextMessage();
-        }
-    }
-
     private Optional<Notice> nextAutoMessage(AutoMessageMessages messageSection) {
         Collection<Notice> messages = messageSection.messages();
 
@@ -97,7 +95,6 @@ class AutoMessageService {
         }
 
         int index = this.broadcastCount.getAndIncrement() % messages.size();
-
         return messages.stream().skip(index).findFirst();
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageTable.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageTable.java
@@ -1,0 +1,18 @@
+package com.eternalcode.core.feature.automessage;
+
+import com.j256.ormlite.field.DatabaseField;
+import com.j256.ormlite.table.DatabaseTable;
+import java.util.UUID;
+
+@DatabaseTable(tableName = "eternal_core_auto_message_ignore")
+class AutoMessageTable {
+
+    @DatabaseField(columnName = "unique_id", id = true)
+    UUID uniqueId;
+
+    AutoMessageTable() {}
+
+    AutoMessageTable(UUID uniqueId) {
+        this.uniqueId = uniqueId;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/messages/ENAutoMessageMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/messages/ENAutoMessageMessages.java
@@ -17,7 +17,7 @@ public class ENAutoMessageMessages implements AutoMessageMessages {
 
     @Description({
         "",
-        "# If you want to useplaceholder %server_online% you need to install",
+        "# If you want to use placeholder %server_online% you need to install",
         "# PlaceholderAPI plugin and download placeholders for Server",
         "# like /papi ecloud download Server",
     })


### PR DESCRIPTION
### Faulty Query:
The `for` loop added `eq` (equality) conditions for each `UUID`, but it did not correctly combine them using the `OR` operator.

The `or(onlineUniqueIds.size())` method did not work as expected because it did not create a proper logical `OR` condition in SQL.

- Let's assume we have 3 online players: `UUID1`, `UUID2`, `UUID3`.
- Player `UUID2` has ignored messages.
- The faulty query might return an incorrect `ignoredIds` list, such as an empty list.
- As a result, all players (including `UUID2`) received messages, even though `UUID2` had ignored them.

#### Correct Behavior (After the Fix):
- The corrected query returns an `ignoredIds` list containing only `UUID2`.
- Messages are sent only to `UUID1` and `UUID3`.
- Player `UUID2` does not receive messages, in accordance with their settings.
