### PR TITLE
Fix IllegalArgumentException when checking player movement across worlds during teleport

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/TeleportTask.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/TeleportTask.java
@@ -101,8 +101,11 @@ class TeleportTask implements Runnable {
 
     private boolean hasPlayerMovedDuringTeleport(Player player, Teleport teleport) {
         Location startLocation = PositionAdapter.convert(teleport.getStartLocation());
-
-        return player.getLocation().distance(startLocation) > 0.5;
+        Location currentLocation = player.getLocation();
+        if (!currentLocation.getWorld().equals(startLocation.getWorld())) {
+            return true; 
+        }
+        return currentLocation.distance(startLocation) > 0.5;
     }
 
 }


### PR DESCRIPTION
**Summary**
This PR fixes an issue where the plugin would throw an `IllegalArgumentException` if it tried to measure the distance between two locations in different worlds during a teleport.

**Details**
- Added a check in `TeleportTask#hasPlayerMovedDuringTeleport` to verify that both locations are in the same world before calling `distance`.
- If the worlds are different, the method now returns `true` (treating the player as having moved), preventing the exception.

**Why?**
This change prevents server errors and ensures the teleportation logic is robust, even when players are teleported between different worlds.

**Related issue:** #935 