### PR TITLE
GH-1034 Add teleport-here all and teleport-here ask-to-all functionality

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
@@ -1,14 +1,15 @@
 package com.eternalcode.core.feature.teleport.command;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
+import com.eternalcode.core.feature.teleport.TeleportService;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
-import com.eternalcode.core.feature.teleport.TeleportService;
 import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
-import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.shortcut.Shortcut;
 import org.bukkit.entity.Player;
 
 @Command(name = "tphere", aliases = { "s" })
@@ -32,6 +33,24 @@ class TeleportHereCommand {
             .notice(translation -> translation.teleport().teleportedPlayerToPlayer())
             .placeholder("{PLAYER}", target.getName())
             .placeholder("{ARG-PLAYER}", sender.getName())
+            .player(sender.getUniqueId())
+            .send();
+    }
+
+    @Execute(name = "all")
+    @Shortcut("tpall")
+    @Permission("eternalcore.tphere.all")
+    @DescriptionDocs(description = "Teleport all players to you")
+    void tpHereAll(@Context Player sender) {
+        for (Player player : sender.getServer().getOnlinePlayers()) {
+            if (player.getUniqueId().equals(sender.getUniqueId())) {
+                continue;
+            }
+            this.teleportService.teleport(player, sender.getLocation());
+        }
+
+        this.noticeService.create()
+            .notice(translation -> translation.teleport().teleportedAllToPlayer())
             .player(sender.getUniqueId())
             .send();
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
@@ -37,7 +37,7 @@ class TeleportHereCommand {
             .send();
     }
 
-    @Execute(name = "all")
+    @Execute(name = "-all", aliases = { "*" })
     @Shortcut("tpall")
     @Permission("eternalcore.tphere.all")
     @DescriptionDocs(description = "Teleport all players to you")

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleport/command/TeleportHereCommand.java
@@ -6,7 +6,7 @@ import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
 import dev.rollczi.litecommands.annotations.argument.Arg;
 import dev.rollczi.litecommands.annotations.command.Command;
-import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.context.Sender;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
 import dev.rollczi.litecommands.annotations.shortcut.Shortcut;
@@ -27,7 +27,7 @@ class TeleportHereCommand {
 
     @Execute
     @DescriptionDocs(description = "Teleport player to you", arguments = "<player>")
-    void tpHere(@Context Player sender, @Arg Player target) {
+    void tpHere(@Sender Player sender, @Arg Player target) {
         this.teleportService.teleport(target, sender.getLocation());
         this.noticeService.create()
             .notice(translation -> translation.teleport().teleportedPlayerToPlayer())
@@ -41,7 +41,7 @@ class TeleportHereCommand {
     @Shortcut("tpall")
     @Permission("eternalcore.tphere.all")
     @DescriptionDocs(description = "Teleport all players to you")
-    void tpHereAll(@Context Player sender) {
+    void tpHereAll(@Sender Player sender) {
         for (Player player : sender.getServer().getOnlinePlayers()) {
             if (player.getUniqueId().equals(sender.getUniqueId())) {
                 continue;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
@@ -16,6 +16,7 @@ public class ENTeleportRequestMessages extends OkaeriConfig implements TeleportR
         Notice.chat("<green>► <white>You have sent a request for player <green>{PLAYER}<white>{PLAYER} to teleport to you!");
 
     public Notice tpaHereSent = Notice.chat("<green>► <white>You have sent a request for teleportation to you for a player: <green>{PLAYER}<white>!");
+    public Notice tpaHereSentToAll = Notice.chat("<green>► <white>You have sent a request for teleportation to all players!");
     public Notice tpaHereReceived = Notice.builder()
         .chat("<green>► <white>You have received a request for teleportation TO a player: <gray>{PLAYER}<green>!")
         .chat(
@@ -72,4 +73,9 @@ public class ENTeleportRequestMessages extends OkaeriConfig implements TeleportR
 
     @Comment(" ")
     public Notice tpaTargetIgnoresYou = Notice.chat("<green>► <red>{PLAYER} <white>is ignoring you!");
+
+    @Override
+    public Notice tpaHereSentToAll() {
+        return null;
+    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
@@ -73,9 +73,4 @@ public class ENTeleportRequestMessages extends OkaeriConfig implements TeleportR
 
     @Comment(" ")
     public Notice tpaTargetIgnoresYou = Notice.chat("<green>► <red>{PLAYER} <white>is ignoring you!");
-
-    @Override
-    public Notice tpaHereSentToAll() {
-        return null;
-    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/ENTeleportRequestMessages.java
@@ -13,7 +13,7 @@ public class ENTeleportRequestMessages extends OkaeriConfig implements TeleportR
     public Notice tpaAlreadySentMessage =
         Notice.chat("<red>✘ <dark_red>You have already sent a teleportation request!");
     public Notice tpaSentMessage =
-        Notice.chat("<green>► <white>You have sent a request for player <green>{PLAYER}<white>{PLAYER} to teleport to you!");
+        Notice.chat("<green>► <white>You have sent a request for player <green>{PLAYER}<white> to teleport to you!");
 
     public Notice tpaHereSent = Notice.chat("<green>► <white>You have sent a request for teleportation to you for a player: <green>{PLAYER}<white>!");
     public Notice tpaHereSentToAll = Notice.chat("<green>► <white>You have sent a request for teleportation to all players!");

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/PLTeleportRequestMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/PLTeleportRequestMessages.java
@@ -16,6 +16,7 @@ public class PLTeleportRequestMessages extends OkaeriConfig implements TeleportR
         Notice.chat("<green>► <white>Wysłałeś prośbę o teleportację do gracza: <green>{PLAYER}<white>!");
 
     public Notice tpaHereSent = Notice.chat("<green>► <white>Wysłałeś prośbę o teleportację gracza <green>{PLAYER}<white> do twojej lokalizacji!");
+    public Notice tpaHereSentToAll = Notice.chat("<green>► <white>Wysłano prośbę o teleportację do wszystkich graczy!");
     public Notice tpaHereReceived = Notice.builder()
         .chat("<green>► <white>Otrzymałeś prośbę o teleportację do gracza: <green>{PLAYER}<white>!")
         .chat(

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/TeleportRequestMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/messages/TeleportRequestMessages.java
@@ -10,6 +10,7 @@ public interface TeleportRequestMessages {
     Notice tpaTargetIgnoresYou();
 
     Notice tpaHereSent();
+    Notice tpaHereSentToAll();
     Notice tpaHereReceived();
 
     Notice tpaDenyNoRequestMessage();

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.feature.teleportrequest.self;
 
+import com.eternalcode.annotations.scan.command.DescriptionDocs;
 import com.eternalcode.core.feature.ignore.IgnoreService;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
@@ -8,6 +9,7 @@ import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Context;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
+import dev.rollczi.litecommands.annotations.shortcut.Shortcut;
 import org.bukkit.entity.Player;
 
 import java.util.concurrent.CompletableFuture;
@@ -28,6 +30,7 @@ class TpaHereCommand {
     }
 
     @Execute
+    @DescriptionDocs(description = "Send teleport request to player to teleport to you", arguments = "<player>")
     void execute(@Context Player sender, @Arg Player target) {
         if (sender.equals(target)) {
             this.noticeService.player(sender.getUniqueId() , translation -> translation.tpa().tpaSelfMessage());
@@ -67,6 +70,43 @@ class TpaHereCommand {
            this.requestService.createRequest(sender.getUniqueId(), target.getUniqueId());
         });
     }
+
+    @Execute(name = "-all")
+    @Shortcut("tpaall")
+    @Permission("eternalcore.tpahere.all")
+    @DescriptionDocs(description = "Send teleport request to all online players to teleport to you")
+    void executeAll(@Context Player sender) {
+        for (Player target : sender.getServer().getOnlinePlayers()) {
+            if (target.getUniqueId().equals(sender.getUniqueId())) {
+                continue;
+            }
+
+            if (this.requestService.hasRequest(sender.getUniqueId(), target.getUniqueId())) {
+                continue;
+            }
+
+            this.isIgnoring(target, sender).thenAccept(isIgnoring -> {
+                if (isIgnoring) {
+                    return;
+                }
+
+                this.noticeService.create()
+                    .player(target.getUniqueId())
+                    .notice(translation -> translation.tpa().tpaHereReceived())
+                    .placeholder("{PLAYER}", sender.getName())
+                    .send();
+
+                this.requestService.createRequest(sender.getUniqueId(), target.getUniqueId());
+
+                this.noticeService.create()
+                    .player(sender.getUniqueId())
+                    .notice(translation -> translation.tpa().tpaHereSentToAll())
+                    .send();
+            });
+        }
+    }
+
+
 
     private CompletableFuture<Boolean> isIgnoring(Player target, Player sender) {
         return this.ignoreService.isIgnored(target.getUniqueId(), sender.getUniqueId());

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
@@ -70,7 +70,7 @@ class TpaHereCommand {
         });
     }
 
-    @Execute(name = "-all")
+    @Execute(name = "-all", aliases = { "*" })
     @Permission("eternalcore.tpahere.all")
     @DescriptionDocs(description = "Send teleport request to all online players to teleport to you")
     void executeAll(@Sender Player sender) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
@@ -98,12 +98,13 @@ class TpaHereCommand {
 
                 this.requestService.createRequest(sender.getUniqueId(), target.getUniqueId());
 
-                this.noticeService.create()
-                    .player(sender.getUniqueId())
-                    .notice(translation -> translation.tpa().tpaHereSentToAll())
-                    .send();
             });
         }
+
+        this.noticeService.create()
+            .player(sender.getUniqueId())
+            .notice(translation -> translation.tpa().tpaHereSentToAll())
+            .send();
     }
 
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/self/TpaHereCommand.java
@@ -6,10 +6,9 @@ import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
 import dev.rollczi.litecommands.annotations.argument.Arg;
 import dev.rollczi.litecommands.annotations.command.Command;
-import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.context.Sender;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
-import dev.rollczi.litecommands.annotations.shortcut.Shortcut;
 import org.bukkit.entity.Player;
 
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +30,7 @@ class TpaHereCommand {
 
     @Execute
     @DescriptionDocs(description = "Send teleport request to player to teleport to you", arguments = "<player>")
-    void execute(@Context Player sender, @Arg Player target) {
+    void execute(@Sender Player sender, @Arg Player target) {
         if (sender.equals(target)) {
             this.noticeService.player(sender.getUniqueId() , translation -> translation.tpa().tpaSelfMessage());
 
@@ -72,10 +71,9 @@ class TpaHereCommand {
     }
 
     @Execute(name = "-all")
-    @Shortcut("tpaall")
     @Permission("eternalcore.tpahere.all")
     @DescriptionDocs(description = "Send teleport request to all online players to teleport to you")
-    void executeAll(@Context Player sender) {
+    void executeAll(@Sender Player sender) {
         for (Player target : sender.getServer().getOnlinePlayers()) {
             if (target.getUniqueId().equals(sender.getUniqueId())) {
                 continue;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -40,6 +40,7 @@ public interface Translation {
         Notice teleportedToPlayer();
         Notice teleportedPlayerToPlayer();
         Notice teleportedToHighestBlock();
+        Notice teleportedAllToPlayer();
 
         // Task
         Notice teleportTimerFormat();

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -182,6 +182,9 @@ public class ENTranslation extends AbstractTranslation {
         @Comment({"# {Y} - Y coordinate of the highest block"})
         public Notice teleportedToHighestBlock = Notice.chat("<green>► <white>Teleported successfully to the highest block! (Y: {Y})");
 
+        @Comment(" ")
+        public Notice teleportedAllToPlayer = Notice.chat("<green>► <white>All players have been teleported to you!");
+
         // Task
         @Comment({"# {TIME} - Teleportation time"})
         public Notice teleportTimerFormat = Notice.actionbar("<green>► <white>Teleporting in <green>{TIME}");

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -179,6 +179,9 @@ public class PLTranslation extends AbstractTranslation {
         @Comment({"# {Y} - Koordynat Y najwyżej położonego bloku"})
         public Notice teleportedToHighestBlock = Notice.chat("<green>► <white>Pomyślnie przeteleportowano do najwyższego bloku! (Y: {Y})");
 
+        @Comment(" ")
+        public Notice teleportedAllToPlayer = Notice.chat("<green>► <white>Przeteleportowano wszystkich graczy do ciebie!");
+
         // Task
         @Comment({"# {TIME} - Czas teleportacji"})
         public Notice teleportTimerFormat = Notice.actionbar("<green>► <white>Teleportacja za <green>{TIME}");


### PR DESCRIPTION
Introduced new functionality for teleportation commands, specifically added support for teleporting all players to a single player and sending teleport requests to all players. It also updated the translation files and interfaces to support these new features.

Closes #1034. 