### PR TITLE
GH-1082 Move the config sections into dedicated classes. Improve `parent` comments of sections.

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -2,31 +2,31 @@ package com.eternalcode.core.configuration.implementation;
 
 import com.eternalcode.core.configuration.AbstractConfigurationFile;
 import com.eternalcode.core.database.DatabaseConfig;
-import com.eternalcode.core.database.DatabaseType;
-import com.eternalcode.core.feature.afk.AfkSettings;
-import com.eternalcode.core.feature.automessage.AutoMessageSettings;
+import com.eternalcode.core.feature.afk.AfkConfig;
+import com.eternalcode.core.feature.automessage.AutoMessageConfig;
+import com.eternalcode.core.feature.butcher.ButcherConfig;
 import com.eternalcode.core.feature.catboy.CatboyConfig;
-import com.eternalcode.core.feature.chat.ChatSettings;
-import com.eternalcode.core.feature.helpop.HelpOpSettings;
-import com.eternalcode.core.feature.jail.JailSettings;
+import com.eternalcode.core.feature.chat.ChatConfig;
+import com.eternalcode.core.feature.helpop.HelpOpConfig;
+import com.eternalcode.core.feature.home.HomesConfig;
+import com.eternalcode.core.feature.jail.JailConfig;
 import com.eternalcode.core.feature.lightning.LightningConfig;
 import com.eternalcode.core.feature.randomteleport.RandomTeleportSettingsImpl;
+import com.eternalcode.core.feature.repair.RepairConfig;
 import com.eternalcode.core.feature.serverlinks.ServerLinksConfig;
+import com.eternalcode.core.feature.spawn.SpawnJoinConfig;
 import com.eternalcode.core.feature.spawn.SpawnSettings;
-import com.eternalcode.core.feature.teleportrequest.TeleportRequestSettings;
+import com.eternalcode.core.feature.teleportrequest.TeleportRequestConfig;
+import com.eternalcode.core.feature.warp.WarpConfig;
 import com.eternalcode.core.injector.annotations.Bean;
 import com.eternalcode.core.injector.annotations.component.ConfigurationFile;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
 import eu.okaeri.configs.annotation.Header;
-import org.bukkit.Material;
 import org.bukkit.Sound;
 
 import java.io.File;
 import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
 
 @Header({
     "#",
@@ -47,51 +47,33 @@ public class PluginConfiguration extends AbstractConfigurationFile {
     @Comment("# Whether the player should receive information about new plugin updates upon joining the server")
     public boolean shouldReceivePluginUpdates = true;
 
-    @Comment
-    @Comment({
-        "Settings responsible for the database connection."
-    })
+    @Comment("")
+    @Comment("# Database Configuration")
+    @Comment("# Settings responsible for the database connection")
     public DatabaseConfig database = new DatabaseConfig();
 
-
-    @Comment({ "", "# Join settings" })
-    public Join join = new Join();
-
-    public static class Join extends OkaeriConfig {
-        @Comment("# Teleport to spawn on first join")
-        public boolean teleportToSpawnOnFirstJoin = true;
-
-        @Comment("# Teleport to spawn on join")
-        public boolean teleportToSpawnOnJoin = false;
-    }
-
+    @Comment("")
+    @Comment("# Spawn & Join Configuration")
+    @Comment("# Settings responsible for player spawn and join behavior")
+    public SpawnJoinConfig join = new SpawnJoinConfig();
 
     @Bean
-    @Comment({ " ", "# Teleport request section" })
-    public TeleportAsk teleportAsk = new TeleportAsk();
-
-    public static class TeleportAsk extends OkaeriConfig implements TeleportRequestSettings {
-        @Comment({ "# Time of tpa requests expire" })
-        public Duration tpaRequestExpire = Duration.ofSeconds(80);
-
-        @Comment({ " ", "# Time of teleportation time in /tpa commands" })
-        public Duration tpaTimer = Duration.ofSeconds(10);
-
-        @Override
-        public Duration teleportExpire() {
-            return this.tpaRequestExpire;
-        }
-
-        @Override
-        public Duration teleportTime() {
-            return this.tpaTimer;
-        }
-    }
+    @Comment("")
+    @Comment("# Teleport Request Configuration")
+    @Comment("# Settings for teleport requests between players")
+    public TeleportRequestConfig teleportAsk = new TeleportRequestConfig();
 
     @Bean
-    @Comment({ " ", "# Teleport section" })
+    @Comment("")
+    @Comment("# Teleport Configuration")
+    @Comment("# General teleportation settings")
     public Teleport teleport = new Teleport();
 
+    // TODO: Add migration, move option's to domain-specific configuration classes
+    // teleportToSpawnOnDeath -> com.eternalcode.core.feature.spawn.SpawnConfig
+    // teleportToRespawnPoint -> com.eternalcode.core.feature.spawn.SpawnConfig
+    // teleportTimeToSpawn -> com.eternalcode.core.feature.spawn.SpawnConfig
+    // includeOpPlayersInRandomTeleport -> com.eternalcode.core.feature.teleportrandomplayer.TeleportRandomPlayerConfig
     public static class Teleport extends OkaeriConfig implements SpawnSettings {
         @Comment("# Teleports the player to spawn after death")
         public boolean teleportToSpawnOnDeath = true;
@@ -99,10 +81,10 @@ public class PluginConfiguration extends AbstractConfigurationFile {
         @Comment("# Teleports the player to respawn point after death")
         public boolean teleportToRespawnPoint = true;
 
-        @Comment("# Time of teleportation to spawn")
+        @Comment("# Time delay before teleporting to spawn")
         public Duration teleportTimeToSpawn = Duration.ofSeconds(5);
 
-        @Comment("# Include players with op in teleport to random player")
+        @Comment("# Include players with OP permission in random teleport selection")
         public boolean includeOpPlayersInRandomTeleport = false;
 
         @Override
@@ -112,295 +94,137 @@ public class PluginConfiguration extends AbstractConfigurationFile {
     }
 
     @Bean
-    @Comment({ "", "# Random Teleport Section" })
+    @Comment("")
+    @Comment("# Random Teleport Configuration")
+    @Comment("# Settings for random teleportation feature")
     public RandomTeleportSettingsImpl randomTeleport = new RandomTeleportSettingsImpl();
 
     @Bean
-    @Comment({ " ", "# Homes Section" })
-    public Homes homes = new Homes();
+    @Comment("")
+    @Comment("# Homes Configuration")
+    @Comment("# Settings for player home management")
+    public HomesConfig homes = new HomesConfig();
 
-    public static class Homes extends OkaeriConfig {
-        @Comment("# Default home name")
-        public String defaultHomeName = "home";
-
-        @Comment("# Time of teleportation to homes")
-        public Duration teleportTimeToHomes = Duration.ofSeconds(5);
-
-        @Comment("# Max homes per permission")
-        public Map<String, Integer> maxHomes = new LinkedHashMap<>() {
-            {
-                put("eternalcore.home.default", 1);
-                put("eternalcore.home.vip", 2);
-                put("eternalcore.home.premium", 3);
-            }
-        };
-    }
-
-    @Comment({ " ", "# Awesome sounds" })
+    @Comment("")
+    @Comment("# Sound Configuration")
+    @Comment("# Settings for various sound effects")
     @Bean
     public Sounds sound = new Sounds();
 
     public static class Sounds extends OkaeriConfig {
-        @Comment("# Do you want to enable sound after player join to server?")
+        @Comment("# Enable sound when player joins the server")
         public boolean enabledAfterJoin = true;
         public Sound afterJoin = Sound.BLOCK_NOTE_BLOCK_PLING;
         public float afterJoinVolume = 1.8F;
         public float afterJoinPitch = 1F;
 
-        @Comment({ " ", "# Do you want to enable sound after player quit server?" })
+        @Comment("")
+        @Comment("# Enable sound when player leaves the server")
         public boolean enableAfterQuit = true;
         public Sound afterQuit = Sound.BLOCK_NOTE_BLOCK_BASEDRUM;
         public float afterQuitVolume = 1.8F;
         public float afterQuitPitch = 1F;
 
-        @Comment({ " ", "# Do you want to enable sound after player send message on chat server?" })
+        @Comment("")
+        @Comment("# Enable sound when player sends a chat message")
         public boolean enableAfterChatMessage = true;
         public Sound afterChatMessage = Sound.ENTITY_ITEM_PICKUP;
         public float afterChatMessageVolume = 1.8F;
         public float afterChatMessagePitch = 1F;
-
     }
 
     @Bean
-    @Comment({ " ", "# Chat Section" })
-    public Chat chat = new Chat();
+    @Comment("")
+    @Comment("# Chat Configuration")
+    @Comment("# Settings for chat management and formatting")
+    public ChatConfig chat = new ChatConfig();
 
-    public static class Chat extends OkaeriConfig implements ChatSettings {
+    @Comment("")
+    @Comment("# HelpOp Configuration")
+    @Comment("# Settings for the help operator system")
+    public HelpOpConfig helpOp = new HelpOpConfig();
 
-        @Comment({ "# Custom message for unknown command" })
-        public boolean replaceStandardHelpMessage = false;
+    @Comment("")
+    @Comment("# Repair Configuration")
+    @Comment("# Settings for item repair functionality")
+    public RepairConfig repair = new RepairConfig();
 
-        @Comment({ " ", "# Chat delay to send next message in chat" })
-        public Duration chatDelay = Duration.ofSeconds(5);
-
-        @Comment({ " ", "# Number of lines that will be cleared when using the /chat clear command" })
-        public int linesToClear = 256;
-
-        @Comment({ " ", "# Chat should be enabled?" })
-        public boolean chatEnabled = true;
-
-        @Override
-        public boolean isChatEnabled() {
-            return this.chatEnabled;
-        }
-
-        @Override
-        public void setChatEnabled(boolean chatEnabled) {
-            this.chatEnabled = chatEnabled;
-        }
-
-        @Override
-        public Duration getChatDelay() {
-            return this.chatDelay;
-        }
-
-        @Override
-        public void setChatDelay(Duration chatDelay) {
-            this.chatDelay = chatDelay;
-        }
-
-        @Override
-        public int linesToClear() {
-            return this.linesToClear;
-        }
-
-    }
-
-    @Comment({ " ", "# HelpOp Section" })
-    public HelpOp helpOp = new HelpOp();
-
-    public static class HelpOp extends OkaeriConfig implements HelpOpSettings {
-
-        @Comment("# Delay to send the next message under /helpop")
-        public Duration helpOpDelay = Duration.ofSeconds(60);
-
-        @Override
-        public Duration getHelpOpDelay() {
-            return this.helpOpDelay;
-        }
-    }
-
-    @Comment({ " ", "# Repair Section" })
-    public Repair repair = new Repair();
-
-    public static class Repair extends OkaeriConfig {
-
-        @Comment({ "# Repair command cooldown" })
-        public Duration repairDelay = Duration.ofSeconds(5);
-
-        public Duration repairDelay() {
-            return this.repairDelay;
-        }
-    }
-
-    @Comment({ " ", "# Additional formatting options" })
+    @Comment("")
+    @Comment("# Format Configuration")
+    @Comment("# Additional formatting options for various features")
     public Format format = new Format();
 
     public static class Format extends OkaeriConfig {
+        @Comment("# Separator used between list items")
         public String separator = "<gray>,</gray> ";
     }
 
     @Bean
-    @Comment({ " ", "# AFK Section" })
-    public Afk afk = new Afk();
+    @Comment("")
+    @Comment("# AFK Configuration")
+    @Comment("# Settings for Away From Keyboard detection and management")
+    public AfkConfig afk = new AfkConfig();
 
-    public static class Afk extends OkaeriConfig implements AfkSettings {
-        @Comment({
-            "# Number of interactions a player must make to have AFK status removed",
-            "# This is for so that stupid miss-click doesn't disable AFK status"
-        })
-        public int interactionsCountDisableAfk = 20;
-
-        @Comment({ " ", "# Time before using the /afk command again" })
-        public Duration afkCommandDelay = Duration.ofSeconds(60);
-
-        @Comment({
-            "# Should a player be marked as AFK automatically?",
-            "# If set to true, the player will be marked as AFK after a certain amount of time of inactivity",
-            "# If set to false, the player will have to use the /afk command to be marked as AFK"
-        })
-        public boolean autoAfk = true;
-
-        @Comment({ " ", "# The amount of time a player must be inactive to be marked as AFK" })
-        public Duration afkInactivityTime = Duration.ofMinutes(10);
-
-        @Comment({ " ", "# Should a player be kicked from the game when marked as AFK?" })
-        public boolean kickOnAfk = false;
-
-        @Override
-        public boolean autoAfk() {
-            return this.autoAfk;
-        }
-
-        @Override
-        public int interactionsCountDisableAfk() {
-            return this.interactionsCountDisableAfk;
-        }
-
-        @Override
-        public Duration getAfkDelay() {
-            return this.afkCommandDelay;
-        }
-
-        @Override
-        public Duration getAfkInactivityTime() {
-            return this.afkInactivityTime;
-        }
-    }
-
-    @Comment({ " ", "# Items" })
+    @Comment("")
+    @Comment("# Items Configuration")
+    @Comment("# Settings for item management and behavior")
     public Items items = new Items();
 
+    // TODO: Add migration, move option's to domain-specific configuration classes
+    // unsafeEnchantments -> com.eternalcode.core.enchant.EnchantConfig
+    // defaultGiveAmount -> com.eternalcode.core.feature.give.GiveConfig
+    // dropOnFullInventory -> com.eternalcode.core.feature.give.GiveConfig
     public static class Items extends OkaeriConfig {
-        @Comment("# Use unsafe enchantments? Allows you to apply custom enchants to various items")
+        @Comment("# Allow unsafe enchantments (enables custom enchants on various items)")
         public boolean unsafeEnchantments = true;
 
-        @Comment({ " ", "# The default item give amount, when no amount is specified in the command." })
+        @Comment("")
+        @Comment("# Default amount of items to give when no amount is specified")
         public int defaultGiveAmount = 1;
 
-        @Comment({ " ", "# Determines whether items should be dropped on the ground when the player's inventory is full" })
+        @Comment("")
+        @Comment("# Drop items on ground when player's inventory is full")
         public boolean dropOnFullInventory = true;
     }
 
-    @Comment({ " ", "# Warp Section" })
-    public Warp warp = new Warp();
+    @Comment("")
+    @Comment("# Warp Configuration")
+    @Comment("# Settings for warp points management")
+    public WarpConfig warp = new WarpConfig();
 
-    public static class Warp extends OkaeriConfig {
-        @Comment("# Time of teleportation to warp")
-        public Duration teleportTimeToWarp = Duration.ofSeconds(5);
-
-        @Comment("# Warp inventory should be enabled?")
-        public boolean inventoryEnabled = true;
-
-        @Comment("# Warp inventory auto add new warps")
-        public boolean autoAddNewWarps = true;
-
-        @Comment({"# Options below allow you to customize item representing warp added to GUI, ",
-            "# you can change almost everything inside langueage files, after the warp has been added to the inventory."})
-        public String itemNamePrefix = "&8» &6Warp: &f";
-
-        public String itemLore = "&7Click to teleport!";
-
-        public Material itemMaterial = Material.PLAYER_HEAD;
-
-        @Comment("# Texture of the item (only for PLAYER_HEAD material)")
-        public String itemTexture = "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzk4ODVlODIzZmYxNTkyNjdjYmU4MDkwOTNlMzNhNDc2ZTI3NDliNjU5OGNhNGEyYTgxZWU2OTczODAzZmI2NiJ9fX0=";
-    }
-
-    @Comment({ " ", "# Butcher" })
-    public Butcher butcher = new Butcher();
-
-    public static class Butcher extends OkaeriConfig {
-        @Comment("# Safe number of chunks for command execution (above this number it will not be possible to execute the command)")
-        public int safeChunkNumber = 5;
-    }
+    @Comment("")
+    @Comment("# Butcher Configuration")
+    @Comment("# Settings for entity removal functionality")
+    public ButcherConfig butcher = new ButcherConfig();
 
     @Bean
-    @Comment({ " ", "# AutoMessage Section" })
-    public AutoMessage autoMessage = new AutoMessage();
-
-    public static class AutoMessage extends OkaeriConfig implements AutoMessageSettings {
-        @Comment("# AutoMessage should be enabled?")
-        public boolean enabled = true;
-
-        @Comment("# Interval between messages")
-        public Duration interval = Duration.ofSeconds(60);
-
-        @Comment("# Draw mode (RANDOM, SEQUENTIAL)")
-        public DrawMode drawMode = DrawMode.RANDOM;
-
-        @Comment("# Minimum number of players on the server to send an auto message.")
-        public int minPlayers = 1;
-
-        @Override
-        public boolean enabled() {
-            return this.enabled;
-        }
-
-        @Override
-        public Duration interval() {
-            return this.interval;
-        }
-
-        @Override
-        public DrawMode drawMode() {
-            return this.drawMode;
-        }
-    }
+    @Comment("")
+    @Comment("# Auto Message Configuration")
+    @Comment("# Settings for automatic message broadcasting")
+    public AutoMessageConfig autoMessage = new AutoMessageConfig();
 
     @Bean
-    @Comment({ " ", "# Jail Section" })
-    public Jail jail = new Jail();
-
-    public static class Jail extends OkaeriConfig implements JailSettings {
-
-        @Comment("# Default jail duration, set if no duration is specified")
-        public Duration defaultJailDuration = Duration.ofMinutes(30);
-
-        @Comment("# Allowed commands in jail")
-        public Set<String> allowedCommands = Set.of("help", "msg", "r", "tell", "me", "helpop");
-
-        @Override
-        public Duration defaultJailDuration() {
-            return this.defaultJailDuration;
-        }
-
-        @Override
-        public Set<String> allowedCommands() {
-            return this.allowedCommands;
-        }
-    }
+    @Comment("")
+    @Comment("# Jail Configuration")
+    @Comment("# Settings for player jail system")
+    public JailConfig jail = new JailConfig();
 
     @Bean
-    @Comment({ " ", "# Settings for catboy feature" })
+    @Comment("")
+    @Comment("# Catboy Configuration")
+    @Comment("# Settings for catboy feature")
     public CatboyConfig catboy = new CatboyConfig();
 
     @Bean
-    @Comment({ " ", "# Settings for lightning strike" })
+    @Comment("")
+    @Comment("# Lightning Configuration")
+    @Comment("# Settings for lightning strike effects")
     public LightningConfig lightning = new LightningConfig();
 
     @Bean
-    @Comment({ " ", "# ServerLinks Section" })
+    @Comment("")
+    @Comment("# Server Links Configuration")
+    @Comment("# Settings for server link management")
     ServerLinksConfig serverLinks = new ServerLinksConfig();
 
     @Override

--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -118,14 +118,12 @@ public class PluginConfiguration extends AbstractConfigurationFile {
         public float afterJoinVolume = 1.8F;
         public float afterJoinPitch = 1F;
 
-        @Comment("")
         @Comment("# Enable sound when player leaves the server")
         public boolean enableAfterQuit = true;
         public Sound afterQuit = Sound.BLOCK_NOTE_BLOCK_BASEDRUM;
         public float afterQuitVolume = 1.8F;
         public float afterQuitPitch = 1F;
 
-        @Comment("")
         @Comment("# Enable sound when player sends a chat message")
         public boolean enableAfterChatMessage = true;
         public Sound afterChatMessage = Sound.ENTITY_ITEM_PICKUP;
@@ -178,11 +176,9 @@ public class PluginConfiguration extends AbstractConfigurationFile {
         @Comment("# Allow unsafe enchantments (enables custom enchants on various items)")
         public boolean unsafeEnchantments = true;
 
-        @Comment("")
         @Comment("# Default amount of items to give when no amount is specified")
         public int defaultGiveAmount = 1;
 
-        @Comment("")
         @Comment("# Drop items on ground when player's inventory is full")
         public boolean dropOnFullInventory = true;
     }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
@@ -15,9 +15,11 @@ public class AfkConfig extends OkaeriConfig implements AfkSettings {
     })
     public int interactionsCountDisableAfk = 20;
 
-    @Comment({" ", "# Time before using the /afk command again"})
+    @Comment("")
+    @Comment("# Time before using the /afk command again")
     public Duration afkCommandDelay = Duration.ofSeconds(60);
 
+    @Comment("")
     @Comment({
         "# Should a player be marked as AFK automatically?",
         "# If set to true, the player will be marked as AFK after a certain amount of time of inactivity",
@@ -25,10 +27,12 @@ public class AfkConfig extends OkaeriConfig implements AfkSettings {
     })
     public boolean autoAfk = true;
 
-    @Comment({" ", "# The amount of time a player must be inactive to be marked as AFK"})
+    @Comment("")
+    @Comment("# The amount of time a player must be inactive to be marked as AFK")
     public Duration afkInactivityTime = Duration.ofMinutes(10);
 
-    @Comment({" ", "# Should a player be kicked from the game when marked as AFK?"})
+    @Comment("")
+    @Comment("# Should a player be kicked from the game when marked as AFK?")
     public boolean kickOnAfk = false;
 
     @Override

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
@@ -15,11 +15,9 @@ public class AfkConfig extends OkaeriConfig implements AfkSettings {
     })
     public int interactionsCountDisableAfk = 20;
 
-    @Comment("")
     @Comment("# Time before using the /afk command again")
     public Duration afkCommandDelay = Duration.ofSeconds(60);
 
-    @Comment("")
     @Comment({
         "# Should a player be marked as AFK automatically?",
         "# If set to true, the player will be marked as AFK after a certain amount of time of inactivity",
@@ -27,11 +25,9 @@ public class AfkConfig extends OkaeriConfig implements AfkSettings {
     })
     public boolean autoAfk = true;
 
-    @Comment("")
     @Comment("# The amount of time a player must be inactive to be marked as AFK")
     public Duration afkInactivityTime = Duration.ofMinutes(10);
 
-    @Comment("")
     @Comment("# Should a player be kicked from the game when marked as AFK?")
     public boolean kickOnAfk = false;
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkConfig.java
@@ -1,0 +1,43 @@
+package com.eternalcode.core.feature.afk;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class AfkConfig extends OkaeriConfig implements AfkSettings {
+    @Comment({
+        "# Number of interactions a player must make to have AFK status removed",
+        "# This is for so that stupid miss-click doesn't disable AFK status"
+    })
+    public int interactionsCountDisableAfk = 20;
+
+    @Comment({" ", "# Time before using the /afk command again"})
+    public Duration afkCommandDelay = Duration.ofSeconds(60);
+
+    @Comment({
+        "# Should a player be marked as AFK automatically?",
+        "# If set to true, the player will be marked as AFK after a certain amount of time of inactivity",
+        "# If set to false, the player will have to use the /afk command to be marked as AFK"
+    })
+    public boolean autoAfk = true;
+
+    @Comment({" ", "# The amount of time a player must be inactive to be marked as AFK"})
+    public Duration afkInactivityTime = Duration.ofMinutes(10);
+
+    @Comment({" ", "# Should a player be kicked from the game when marked as AFK?"})
+    public boolean kickOnAfk = false;
+
+    @Override
+    public Duration getAfkDelay() {
+        return this.afkCommandDelay;
+    }
+
+    @Override
+    public Duration getAfkInactivityTime() {
+        return this.afkInactivityTime;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/automessage/AutoMessageConfig.java
@@ -1,0 +1,23 @@
+package com.eternalcode.core.feature.automessage;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class AutoMessageConfig extends OkaeriConfig implements AutoMessageSettings {
+    @Comment("# AutoMessage should be enabled?")
+    public boolean enabled = true;
+
+    @Comment("# Interval between messages")
+    public Duration interval = Duration.ofSeconds(60);
+
+    @Comment("# Draw mode (RANDOM, SEQUENTIAL)")
+    public DrawMode drawMode = DrawMode.RANDOM;
+
+    @Comment("# Minimum number of players on the server to send an auto message.")
+    public int minPlayers = 1;
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/butcher/ButcherConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/butcher/ButcherConfig.java
@@ -1,0 +1,13 @@
+package com.eternalcode.core.feature.butcher;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class ButcherConfig extends OkaeriConfig {
+    @Comment("# Safe number of chunks for command execution (above this number it will not be possible to execute the command)")
+    public int safeChunkNumber = 5;
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
@@ -1,0 +1,45 @@
+package com.eternalcode.core.feature.chat;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class ChatConfig extends OkaeriConfig implements ChatSettings {
+
+    @Comment({"# Custom message for unknown command"})
+    public boolean replaceStandardHelpMessage = false;
+
+    @Comment({" ", "# Chat delay to send next message in chat"})
+    public Duration chatDelay = Duration.ofSeconds(5);
+
+    @Comment({" ", "# Number of lines that will be cleared when using the /chat clear command"})
+    public int linesToClear = 256;
+
+    @Comment({" ", "# Chat should be enabled?"})
+    public boolean chatEnabled = true;
+
+    @Override
+    public boolean isChatEnabled() {
+        return this.chatEnabled;
+    }
+
+    @Override
+    public void setChatEnabled(boolean chatEnabled) {
+        this.chatEnabled = chatEnabled;
+    }
+
+    @Override
+    public Duration getChatDelay() {
+        return this.chatDelay;
+    }
+
+    @Override
+    public void setChatDelay(Duration chatDelay) {
+        this.chatDelay = chatDelay;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
@@ -4,23 +4,25 @@ import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
 import java.time.Duration;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.Accessors;
 
 @Getter
 @Accessors(fluent = true)
 public class ChatConfig extends OkaeriConfig implements ChatSettings {
 
-    @Comment({"# Custom message for unknown command"})
+    @Comment("# Custom message for unknown command")
     public boolean replaceStandardHelpMessage = false;
 
-    @Comment({" ", "# Chat delay to send next message in chat"})
+    @Comment("")
+    @Comment("# Chat delay to send next message in chat")
     public Duration chatDelay = Duration.ofSeconds(5);
 
-    @Comment({" ", "# Number of lines that will be cleared when using the /chat clear command"})
+    @Comment("")
+    @Comment("# Number of lines that will be cleared when using the /chat clear command")
     public int linesToClear = 256;
 
-    @Comment({" ", "# Chat should be enabled?"})
+    @Comment("")
+    @Comment("# Chat should be enabled?")
     public boolean chatEnabled = true;
 
     @Override

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/chat/ChatConfig.java
@@ -13,15 +13,12 @@ public class ChatConfig extends OkaeriConfig implements ChatSettings {
     @Comment("# Custom message for unknown command")
     public boolean replaceStandardHelpMessage = false;
 
-    @Comment("")
     @Comment("# Chat delay to send next message in chat")
     public Duration chatDelay = Duration.ofSeconds(5);
 
-    @Comment("")
     @Comment("# Number of lines that will be cleared when using the /chat clear command")
     public int linesToClear = 256;
 
-    @Comment("")
     @Comment("# Chat should be enabled?")
     public boolean chatEnabled = true;
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/helpop/HelpOpConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/helpop/HelpOpConfig.java
@@ -1,0 +1,20 @@
+package com.eternalcode.core.feature.helpop;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class HelpOpConfig extends OkaeriConfig implements HelpOpSettings {
+
+    @Comment("# Delay to send the next message under /helpop")
+    public Duration helpOpDelay = Duration.ofSeconds(60);
+
+    @Override
+    public Duration getHelpOpDelay() {
+        return this.helpOpDelay;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -1,0 +1,28 @@
+package com.eternalcode.core.feature.home;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class HomesConfig extends OkaeriConfig {
+    @Comment("# Default home name")
+    public String defaultHomeName = "home";
+
+    @Comment("# Time of teleportation to homes")
+    public Duration teleportTimeToHomes = Duration.ofSeconds(5);
+
+    @Comment("# Max homes per permission")
+    public Map<String, Integer> maxHomes = new LinkedHashMap<>() {
+        {
+            put("eternalcore.home.default", 1);
+            put("eternalcore.home.vip", 2);
+            put("eternalcore.home.premium", 3);
+        }
+    };
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/command/HomeCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/command/HomeCommand.java
@@ -1,7 +1,7 @@
 package com.eternalcode.core.feature.home.command;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
-import com.eternalcode.core.configuration.implementation.PluginConfiguration;
+import com.eternalcode.core.feature.home.HomesConfig;
 import com.eternalcode.core.feature.home.Home;
 import com.eternalcode.core.feature.home.HomeService;
 import com.eternalcode.core.feature.home.HomeTeleportService;
@@ -21,14 +21,14 @@ import org.bukkit.entity.Player;
 @Permission("eternalcore.home")
 class HomeCommand {
 
-    private final PluginConfiguration.Homes homesConfig;
+    private final HomesConfig homesConfig;
     private final NoticeService noticeService;
     private final HomeService homeService;
     private final HomeTeleportService homeTeleportService;
 
     @Inject
     HomeCommand(
-        PluginConfiguration.Homes homesConfig,
+        HomesConfig homesConfig,
         NoticeService noticeService,
         HomeService homeService,
         HomeTeleportService homeTeleportService

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
@@ -14,16 +14,7 @@ public class JailConfig extends OkaeriConfig implements JailSettings {
     @Comment("# Default jail duration, set if no duration is specified")
     public Duration defaultJailDuration = Duration.ofMinutes(30);
 
+    @Comment("")
     @Comment("# Allowed commands in jail")
     public Set<String> allowedCommands = Set.of("help", "msg", "r", "tell", "me", "helpop");
-
-    @Override
-    public Duration defaultJailDuration() {
-        return this.defaultJailDuration;
-    }
-
-    @Override
-    public Set<String> allowedCommands() {
-        return this.allowedCommands;
-    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
@@ -14,7 +14,6 @@ public class JailConfig extends OkaeriConfig implements JailSettings {
     @Comment("# Default jail duration, set if no duration is specified")
     public Duration defaultJailDuration = Duration.ofMinutes(30);
 
-    @Comment("")
     @Comment("# Allowed commands in jail")
     public Set<String> allowedCommands = Set.of("help", "msg", "r", "tell", "me", "helpop");
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/jail/JailConfig.java
@@ -1,0 +1,29 @@
+package com.eternalcode.core.feature.jail;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import java.util.Set;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class JailConfig extends OkaeriConfig implements JailSettings {
+
+    @Comment("# Default jail duration, set if no duration is specified")
+    public Duration defaultJailDuration = Duration.ofMinutes(30);
+
+    @Comment("# Allowed commands in jail")
+    public Set<String> allowedCommands = Set.of("help", "msg", "r", "tell", "me", "helpop");
+
+    @Override
+    public Duration defaultJailDuration() {
+        return this.defaultJailDuration;
+    }
+
+    @Override
+    public Set<String> allowedCommands() {
+        return this.allowedCommands;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/lightning/LightningConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/lightning/LightningConfig.java
@@ -8,10 +8,10 @@ import lombok.experimental.Accessors;
 @Getter
 @Accessors(fluent = true)
 public class LightningConfig extends OkaeriConfig implements LightningSettings {
-    @Comment({" ", "# Maximum distance for the lightning strike block when using /lightning."})
+    @Comment("# Maximum distance for the lightning strike block when using /lightning.")
     @Comment("# If you will look at a block that is further than this distance, the lightning will strike at the player.")
     public int maxLightningBlockDistance = 100;
 
-    @Comment({" ", "# If there is no block in the range of lightning strike, should the lightning strike the player?"})
+    @Comment("# If there is no block in the range of lightning strike, should the lightning strike the player?")
     public boolean lightningStrikePlayerIfNoBlock = true;
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairConfig.java
@@ -10,10 +10,6 @@ import lombok.experimental.Accessors;
 @Accessors(fluent = true)
 public class RepairConfig extends OkaeriConfig {
 
-    @Comment({"# Repair command cooldown"})
+    @Comment("# Repair command cooldown")
     public Duration repairDelay = Duration.ofSeconds(5);
-
-    public Duration repairDelay() {
-        return this.repairDelay;
-    }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairConfig.java
@@ -1,0 +1,19 @@
+package com.eternalcode.core.feature.repair;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class RepairConfig extends OkaeriConfig {
+
+    @Comment({"# Repair command cooldown"})
+    public Duration repairDelay = Duration.ofSeconds(5);
+
+    public Duration repairDelay() {
+        return this.repairDelay;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnJoinConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/spawn/SpawnJoinConfig.java
@@ -1,0 +1,16 @@
+package com.eternalcode.core.feature.spawn;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class SpawnJoinConfig extends OkaeriConfig {
+    @Comment("# Teleport to spawn on first join")
+    public boolean teleportToSpawnOnFirstJoin = true;
+
+    @Comment("# Teleport to spawn on join")
+    public boolean teleportToSpawnOnJoin = false;
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
@@ -8,7 +8,6 @@ public class TeleportRequestConfig extends OkaeriConfig implements TeleportReque
     @Comment("# Time of tpa requests expire")
     public Duration tpaRequestExpire = Duration.ofSeconds(80);
 
-    @Comment("")
     @Comment("# Time of teleportation time in /tpa commands")
     public Duration tpaTimer = Duration.ofSeconds(10);
 

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
@@ -5,10 +5,11 @@ import eu.okaeri.configs.annotation.Comment;
 import java.time.Duration;
 
 public class TeleportRequestConfig extends OkaeriConfig implements TeleportRequestSettings {
-    @Comment({"# Time of tpa requests expire"})
+    @Comment("# Time of tpa requests expire")
     public Duration tpaRequestExpire = Duration.ofSeconds(80);
 
-    @Comment({" ", "# Time of teleportation time in /tpa commands"})
+    @Comment("")
+    @Comment("# Time of teleportation time in /tpa commands")
     public Duration tpaTimer = Duration.ofSeconds(10);
 
     @Override

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/teleportrequest/TeleportRequestConfig.java
@@ -1,0 +1,23 @@
+package com.eternalcode.core.feature.teleportrequest;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+
+public class TeleportRequestConfig extends OkaeriConfig implements TeleportRequestSettings {
+    @Comment({"# Time of tpa requests expire"})
+    public Duration tpaRequestExpire = Duration.ofSeconds(80);
+
+    @Comment({" ", "# Time of teleportation time in /tpa commands"})
+    public Duration tpaTimer = Duration.ofSeconds(10);
+
+    @Override
+    public Duration teleportExpire() {
+        return this.tpaRequestExpire;
+    }
+
+    @Override
+    public Duration teleportTime() {
+        return this.tpaTimer;
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/warp/WarpConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/warp/WarpConfig.java
@@ -1,0 +1,33 @@
+package com.eternalcode.core.feature.warp;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import java.time.Duration;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+import org.bukkit.Material;
+
+@Getter
+@Accessors(fluent = true)
+public class WarpConfig extends OkaeriConfig {
+    @Comment("# Time of teleportation to warp")
+    public Duration teleportTimeToWarp = Duration.ofSeconds(5);
+
+    @Comment("# Warp inventory should be enabled?")
+    public boolean inventoryEnabled = true;
+
+    @Comment("# Warp inventory auto add new warps")
+    public boolean autoAddNewWarps = true;
+
+    @Comment({"# Options below allow you to customize item representing warp added to GUI, ",
+              "# you can change almost everything inside langueage files, after the warp has been added to the inventory."})
+    public String itemNamePrefix = "&8» &6Warp: &f";
+
+    public String itemLore = "&7Click to teleport!";
+
+    public Material itemMaterial = Material.PLAYER_HEAD;
+
+    @Comment("# Texture of the item (only for PLAYER_HEAD material)")
+    public String itemTexture =
+        "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzk4ODVlODIzZmYxNTkyNjdjYmU4MDkwOTNlMzNhNDc2ZTI3NDliNjU5OGNhNGEyYTgxZWU2OTczODAzZmI2NiJ9fX0=";
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/warp/WarpConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/warp/WarpConfig.java
@@ -20,7 +20,7 @@ public class WarpConfig extends OkaeriConfig {
     public boolean autoAddNewWarps = true;
 
     @Comment({"# Options below allow you to customize item representing warp added to GUI, ",
-              "# you can change almost everything inside langueage files, after the warp has been added to the inventory."})
+              "# you can change almost everything inside language files, after the warp has been added to the inventory."})
     public String itemNamePrefix = "&8» &6Warp: &f";
 
     public String itemLore = "&7Click to teleport!";


### PR DESCRIPTION
Fixes: #1082 

**No migrations are needed; okaeri-configs will update the comments itself, and nothing else has changed. Everything is compatible with the old config.**

**Standard:
Spacing between parent sections; no spacing between configuration options.**


Actual generated config after changes:
```yaml
#
# This is the main configuration file for EternalCore.
#
# If you need help with the configuration or have any questions related to EternalCore, join our discord, or create an issue on our GitHub.
#
# Issues: https://github.com/EternalCodeTeam/EternalCore/issues
# Discord: https://discord.gg/FQ7jmGBd6c
# Website: https://eternalcode.pl/
# Source Code: https://github.com/EternalCodeTeam/EternalCore
#
# Whether the player should receive information about new plugin updates upon joining the server
shouldReceivePluginUpdates: true

# Database Configuration
# Settings responsible for the database connection
database:
  # Type of the database driver (e.g., SQLITE, H2, MYSQL, MARIADB, POSTGRESQL).
  # Determines the database type to be used.
  databaseType: "SQLITE"
  # Hostname of the database server.
  # For local databases, this is usually 'localhost'.
  hostname: "localhost"
  # Port number of the database server. Common ports:
  #  - MySQL: 3306
  #  - PostgreSQL: 5432
  #  - H2: Not applicable (file-based)
  #  - SQLite: Not applicable (file-based)
  port: 3306
  # Name of the database to connect to. This is the name of the specific database instance.
  database: "eternalcore"
  # Username for the database connection. This is the user account used to authenticate with the database.
  username: "root"
  # Password for the database connection. This is the password for the specified user account.
  password: "password"
  # Enable SSL for the database connection. Set to true to use SSL/TLS for secure connections.
  ssl: false
  # Connection pool size. This determines the maximum number of connections in the pool.
  poolSize: 16
  # Connection timeout in milliseconds. This is the maximum time to wait for a connection from the pool.
  timeout: 30000

# Spawn & Join Configuration
# Settings responsible for player spawn and join behavior
join:
  # Teleport to spawn on first join
  teleportToSpawnOnFirstJoin: true
  # Teleport to spawn on join
  teleportToSpawnOnJoin: false

# Teleport Request Configuration
# Settings for teleport requests between players
teleportAsk:
  # Time of tpa requests expire
  tpaRequestExpire: "1m20s"
  # Time of teleportation time in /tpa commands
  tpaTimer: "10s"

# Teleport Configuration
# General teleportation settings
teleport:
  # Teleports the player to spawn after death
  teleportToSpawnOnDeath: true
  # Teleports the player to respawn point after death
  teleportToRespawnPoint: true
  # Time delay before teleporting to spawn
  teleportTimeToSpawn: "5s"
  # Include players with OP permission in random teleport selection
  includeOpPlayersInRandomTeleport: false

# Random Teleport Configuration
# Settings for random teleportation feature
randomTeleport:
  # Delay to wait for the random teleportation
  delay: "5s"
  # Cooldown for random teleportation
  cooldown: "1m"
  # Type of radius for random teleportation
  # WORLD_BORDER_RADIUS - radius based on the world-border size.
  # STATIC_RADIUS - static radius based on the configuration.
  radiusType: "WORLD_BORDER_RADIUS"
  # Radius of random teleportation, this uses for starting point spawn via /setworldspawn.
  # If you want to use a static radius, set the type to STATIC_RADIUS and set the radius here.
  # If you using WORLD_BORDER_RADIUS, this value will be ignored.
  radius:
    minX: -5000
    maxX: 5000
    minZ: -5000
    maxZ: 5000
  # Teleport to a specific world, if left empty it will teleport to the player's current world
  world: "world"
  # Number of attempts to find a safe location for random teleportation
  teleportAttempts: 10
  # Unsafe blocks for random teleportation
  # These blocks are considered unsafe for players to be teleported onto.
  # The list includes blocks that can cause damage, suffocation, or other
  # undesirable effects. Ensure that the list is comprehensive to avoid
  # teleporting players to hazardous locations.
  unsafeBlocks:
  - "BEDROCK"
  - "BUBBLE_COLUMN"
  - "CACTUS"
  - "COBWEB"
  - "FIRE"
  - "LAVA"
  - "MAGMA_BLOCK"
  - "POWDER_SNOW"
  - "SEAGRASS"
  - "SWEET_BERRY_BUSH"
  - "TALL_SEAGRASS"
  - "TNT"
  - "WATER"
  - "WITHER_ROSE"
  # Air blocks for random teleportation
  # These blocks are considered safe for players to be teleported into.
  # The list includes blocks that do not cause damage or impede movement.
  # Ensure that the list is comprehensive to avoid teleporting players
  # into solid or hazardous blocks.
  airBlocks:
  - "AIR"
  - "STRING"
  - "ACTIVATOR_RAIL"
  - "ALLIUM"
  - "AZURE_BLUET"
  - "BLUE_ORCHID"
  - "CAVE_AIR"
  - "COMPARATOR"
  - "CORNFLOWER"
  - "DANDELION"
  - "DEAD_BUSH"
  - "DETECTOR_RAIL"
  - "LARGE_FERN"
  - "LEVER"
  - "LILAC"
  - "LILY_OF_THE_VALLEY"
  - "ORANGE_TULIP"
  - "OXEYE_DAISY"
  - "PEONY"
  - "PINK_TULIP"
  - "POPPY"
  - "POWERED_RAIL"
  - "RAIL"
  - "RED_TULIP"
  - "REDSTONE_WIRE"
  - "REPEATER"
  - "ROSE_BUSH"
  - "SHORT_GRASS"
  - "SNOW"
  - "STRUCTURE_VOID"
  - "SUNFLOWER"
  - "TALL_GRASS"
  - "VINE"
  - "WALL_TORCH"
  - "WHITE_TULIP"
  - "LEGACY_GRASS"
  - "LEGACY_LONG_GRASS"
  - "LEGACY_DEAD_BUSH"
  # Height range for random teleportation
  # - Minimum: -64 (1.18+) or 0 (older versions)
  # - Maximum: 320 (1.18+) or 256 (older versions)
  # - Default range: 60-160 blocks
  # Note: Values are automatically capped to world height limits
  heightRange:
    minY: 60
    maxY: 160

# Homes Configuration
# Settings for player home management
homes:
  # Default home name
  defaultHomeName: "home"
  # Time of teleportation to homes
  teleportTimeToHomes: "5s"
  # Max homes per permission
  maxHomes:
    eternalcore.home.default: 1
    eternalcore.home.vip: 2
    eternalcore.home.premium: 3

# Sound Configuration
# Settings for various sound effects
sound:
  # Enable sound when player joins the server
  enabledAfterJoin: true
  afterJoin: "BLOCK.NOTE_BLOCK.PLING"
  afterJoinVolume: 1.8
  afterJoinPitch: 1.0
  # Enable sound when player leaves the server
  enableAfterQuit: true
  afterQuit: "BLOCK.NOTE_BLOCK.BASEDRUM"
  afterQuitVolume: 1.8
  afterQuitPitch: 1.0
  # Enable sound when player sends a chat message
  enableAfterChatMessage: true
  afterChatMessage: "ENTITY.ITEM.PICKUP"
  afterChatMessageVolume: 1.8
  afterChatMessagePitch: 1.0

# Chat Configuration
# Settings for chat management and formatting
chat:
  # Custom message for unknown command
  replaceStandardHelpMessage: false
  # Chat delay to send next message in chat
  chatDelay: "5s"
  # Number of lines that will be cleared when using the /chat clear command
  linesToClear: 256
  # Chat should be enabled?
  chatEnabled: true

# HelpOp Configuration
# Settings for the help operator system
helpOp:
  # Delay to send the next message under /helpop
  helpOpDelay: "1m"

# Repair Configuration
# Settings for item repair functionality
repair:
  # Repair command cooldown
  repairDelay: "5s"

# Format Configuration
# Additional formatting options for various features
format:
  # Separator used between list items
  separator: "<gray>,</gray> "

# AFK Configuration
# Settings for Away From Keyboard detection and management
afk:
  # Number of interactions a player must make to have AFK status removed
  # This is for so that stupid miss-click doesn't disable AFK status
  interactionsCountDisableAfk: 20
  # Time before using the /afk command again
  afkCommandDelay: "1m"
  # Should a player be marked as AFK automatically?
  # If set to true, the player will be marked as AFK after a certain amount of time of inactivity
  # If set to false, the player will have to use the /afk command to be marked as AFK
  autoAfk: true
  # The amount of time a player must be inactive to be marked as AFK
  afkInactivityTime: "10m"
  # Should a player be kicked from the game when marked as AFK?
  kickOnAfk: false

# Items Configuration
# Settings for item management and behavior
items:
  # Allow unsafe enchantments (enables custom enchants on various items)
  unsafeEnchantments: true
  # Default amount of items to give when no amount is specified
  defaultGiveAmount: 1
  # Drop items on ground when player's inventory is full
  dropOnFullInventory: true

# Warp Configuration
# Settings for warp points management
warp:
  # Time of teleportation to warp
  teleportTimeToWarp: "5s"
  # Warp inventory should be enabled?
  inventoryEnabled: true
  # Warp inventory auto add new warps
  autoAddNewWarps: true
  # Options below allow you to customize item representing warp added to GUI, 
  # you can change almost everything inside langueage files, after the warp has been added to the inventory.
  itemNamePrefix: "&8» &6Warp: &f"
  itemLore: "&7Click to teleport!"
  itemMaterial: "PLAYER_HEAD"
  # Texture of the item (only for PLAYER_HEAD material)
  itemTexture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzk4ODVlODIzZmYxNTkyNjdjYmU4MDkwOTNlMzNhNDc2ZTI3NDliNjU5OGNhNGEyYTgxZWU2OTczODAzZmI2NiJ9fX0="

# Butcher Configuration
# Settings for entity removal functionality
butcher:
  # Safe number of chunks for command execution (above this number it will not be possible to execute the command)
  safeChunkNumber: 5

# Auto Message Configuration
# Settings for automatic message broadcasting
autoMessage:
  # AutoMessage should be enabled?
  enabled: true
  # Interval between messages
  interval: "1m"
  # Draw mode (RANDOM, SEQUENTIAL)
  drawMode: "RANDOM"
  # Minimum number of players on the server to send an auto message.
  minPlayers: 1

# Jail Configuration
# Settings for player jail system
jail:
  # Default jail duration, set if no duration is specified
  defaultJailDuration: "30m"
  # Allowed commands in jail
  allowedCommands:
  - "help"
  - "helpop"
  - "tell"
  - "me"
  - "msg"
  - "r"

# Catboy Configuration
# Settings for catboy feature
catboy:
  # Speed of player walk speed while using /catboy feature
  # Default minecraft walk speed is 0.2
  catboyWalkSpeed: 0.4

# Lightning Configuration
# Settings for lightning strike effects
lightning:
  # Maximum distance for the lightning strike block when using /lightning.
  # If you will look at a block that is further than this distance, the lightning will strike at the player.
  maxLightningBlockDistance: 100
  # If there is no block in the range of lightning strike, should the lightning strike the player?
  lightningStrikePlayerIfNoBlock: true

# Server Links Configuration
# Settings for server link management
serverLinks:
  # Configuration of server links displayed in the ESC/pause menu
  # Links will be visible in the game's pause menu under server information
  # Note: This feature requires Minecraft version 1.21 or newer to work properly
  sendLinksOnJoin: true
  serverLinks:
  - name: "<rainbow>Discord"
    address: "https://discord.gg/v2rkPb4Q2r"
  - name: "Website"
    address: "https://www.eternalcode.pl"


```