### PR TITLE
Add playtime command and messages support

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/PlaytimeCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/PlaytimeCommand.java
@@ -1,0 +1,56 @@
+package com.eternalcode.core.feature.playtime;
+
+import com.eternalcode.annotations.scan.command.DescriptionDocs;
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.notice.NoticeService;
+import com.eternalcode.core.util.DurationUtil;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import dev.rollczi.litecommands.annotations.permission.Permission;
+import org.bukkit.Statistic;
+import org.bukkit.entity.Player;
+
+import java.time.Duration;
+
+@Command(name = "playtime", aliases = {"play-time", "pt"})
+@Permission("eternalcore.playtime")
+public class PlaytimeCommand {
+
+    private final NoticeService noticeService;
+
+    @Inject
+    public PlaytimeCommand(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    @Execute
+    @DescriptionDocs(description = "Show your playtime")
+    void self(@Context Player player) {
+        this.noticeService.create()
+            .notice(translation -> translation.playtime().self())
+            .placeholder("{PLAYTIME}", this.formatPlaytime(player))
+            .player(player.getUniqueId())
+            .send();
+    }
+
+    @Execute
+    @DescriptionDocs(description = "Show playtime of a player", arguments = "<player>")
+    void other(@Context Player player, @Arg Player target) {
+        this.noticeService.create()
+            .notice(translation -> translation.playtime().other())
+            .placeholder("{PLAYER}", target.getName())
+            .placeholder("{PLAYTIME}", this.formatPlaytime(target))
+            .player(player.getUniqueId())
+            .send();
+    }
+
+    private String formatPlaytime(Player player) {
+        int ticks = player.getStatistic(Statistic.PLAY_ONE_MINUTE);
+        Duration playtime = Duration.ofSeconds(ticks / 20L);
+
+        return DurationUtil.format(playtime, true)
+            .replaceAll("(?<=[a-zA-Z])(?=\\d)", " ");
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/ENPlaytimeMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/ENPlaytimeMessages.java
@@ -1,0 +1,15 @@
+package com.eternalcode.core.feature.playtime.messages;
+
+import com.eternalcode.multification.notice.Notice;
+import eu.okaeri.configs.OkaeriConfig;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class ENPlaytimeMessages extends OkaeriConfig implements PlaytimeMessages {
+
+    public Notice self = Notice.chat("<green>► <white>Your playing time is <green>{PLAYTIME}</green>!</white>");
+
+    public Notice other = Notice.chat("<green>► <white>The playing time of <green>{PLAYER}</green> is <green>{PLAYTIME}</green>!</white>");
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/PLPlaytimeMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/PLPlaytimeMessages.java
@@ -1,0 +1,15 @@
+package com.eternalcode.core.feature.playtime.messages;
+
+import com.eternalcode.multification.notice.Notice;
+import eu.okaeri.configs.OkaeriConfig;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors(fluent = true)
+public class PLPlaytimeMessages extends OkaeriConfig implements PlaytimeMessages {
+
+    public Notice self = Notice.chat("<green>► <white>Twój czas gry wynosi <green>{PLAYTIME}</green>!</white>");
+
+    public Notice other = Notice.chat("<green>► <white>Czas gry gracza <green>{PLAYER}</green> wynosi <green>{PLAYTIME}</green>!</white>");
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/PlaytimeMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/playtime/messages/PlaytimeMessages.java
@@ -1,0 +1,10 @@
+package com.eternalcode.core.feature.playtime.messages;
+
+import com.eternalcode.multification.notice.Notice;
+
+public interface PlaytimeMessages {
+
+    Notice self();
+    Notice other();
+
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/Translation.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.translation;
 
+import com.eternalcode.core.feature.playtime.messages.PlaytimeMessages;
 import com.eternalcode.core.litecommand.argument.messages.ArgumentMessages;
 import com.eternalcode.core.configuration.contextual.ConfigItem;
 import com.eternalcode.core.feature.adminchat.messages.AdminChatMessages;
@@ -241,4 +242,6 @@ public interface Translation {
     VanishMessages vanish();
     // motd section
     MotdMessages motd();
+    // playtime section
+    PlaytimeMessages playtime();
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/ENTranslation.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.translation.implementation;
 
+import com.eternalcode.core.feature.playtime.messages.ENPlaytimeMessages;
 import com.eternalcode.core.litecommand.argument.messages.ENArgumentMessages;
 import com.eternalcode.core.configuration.contextual.ConfigItem;
 import com.eternalcode.core.feature.adminchat.messages.ENAdminChatMessages;
@@ -556,4 +557,7 @@ public class ENTranslation extends AbstractTranslation {
 
     @Comment({" ", "# This section is responsible for the messages of the MOTD feature."})
     public ENMotdMessages motd = new ENMotdMessages();
+
+    @Comment({" ", "# This section is responsible for information about players' game time."})
+    public ENPlaytimeMessages playtime = new ENPlaytimeMessages();
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/translation/implementation/PLTranslation.java
@@ -1,5 +1,6 @@
 package com.eternalcode.core.translation.implementation;
 
+import com.eternalcode.core.feature.playtime.messages.PLPlaytimeMessages;
 import com.eternalcode.core.litecommand.argument.messages.PLArgumentMessages;
 import com.eternalcode.core.configuration.contextual.ConfigItem;
 import com.eternalcode.core.feature.adminchat.messages.PLAdminChatMessages;
@@ -580,4 +581,7 @@ public class PLTranslation extends AbstractTranslation {
 
     @Comment({" ", "# Ta sekcja odpowiada za funkcję MOTD (Message of the Day)"})
     public PLMotdMessages motd = new PLMotdMessages();
+
+    @Comment({" ", "# Ta sekcja odpowiada za wiadomości o czasie gry graczy."})
+    public PLPlaytimeMessages playtime = new PLPlaytimeMessages();
 }


### PR DESCRIPTION
Introduces PlaytimeCommand to display player playtime, with localized messages in English and Polish. Updates translation interfaces and implementations to support playtime messages.

<img width="387" height="34" alt="image" src="https://github.com/user-attachments/assets/39a77a43-719a-46d5-b4d8-b2319217152d" />
