### PR TITLE
GH-1126 Enable Gradle configuration cache and parallel configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,5 @@
 
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true


### PR DESCRIPTION
As gradle 9.0 is stable now.