### PR TITLE
Track relocations globally instead of per-dependency

### DIFF
--- a/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/relocation/RelocationCacheResolver.java
+++ b/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/relocation/RelocationCacheResolver.java
@@ -1,9 +1,6 @@
 package com.eternalcode.core.loader.relocation;
 
-import com.eternalcode.core.loader.dependency.Dependency;
 import com.eternalcode.core.loader.repository.LocalRepository;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -15,22 +12,21 @@ public class RelocationCacheResolver {
 
     private static final String RELOCATIONS_FILE = "relocations.txt";
 
-    private final LocalRepository localRepository;
+    private final File relocationsFile;
 
     public RelocationCacheResolver(LocalRepository localRepository) {
-        this.localRepository = localRepository;
+        this.relocationsFile = localRepository.getRepositoryFolder().resolve(RELOCATIONS_FILE).toFile();
     }
 
-    public boolean shouldForceRelocate(Dependency dependency, List<Relocation> relocations) {
-        return this.getRawSavedRelocations(dependency)
+    public boolean shouldForceRelocate(List<Relocation> relocations) {
+        return this.getSavedRelocations()
             .map(savedRelocations -> !savedRelocations.equals(toRawRelocations(relocations)))
             .orElse(true);
     }
 
-    public void markAsRelocated(Dependency dependency, List<Relocation> relocations) {
+    public void markAsRelocated(List<Relocation> relocations) {
         try {
-            File relocationsCache = dependency.toResource(localRepository, RELOCATIONS_FILE).toFile();
-            Files.writeString(relocationsCache.toPath(), toRawRelocations(relocations), StandardCharsets.UTF_8);
+            Files.writeString(relocationsFile.toPath(), toRawRelocations(relocations), StandardCharsets.UTF_8);
         } catch (Exception exception) {
             throw new RuntimeException("Failed to save relocations", exception);
         }
@@ -42,16 +38,14 @@ public class RelocationCacheResolver {
             .collect(Collectors.joining("\n"));
     }
 
-    private Optional<String> getRawSavedRelocations(Dependency dependency) {
+    private Optional<String> getSavedRelocations() {
         try {
-            File relocationsCache = dependency.toResource(localRepository, RELOCATIONS_FILE).toFile();
-            if (!relocationsCache.exists()) {
+            if (!relocationsFile.exists()) {
                 return Optional.empty();
             }
-            return Optional.of(Files.readString(relocationsCache.toPath()));
+            return Optional.of(Files.readString(relocationsFile.toPath(), StandardCharsets.UTF_8));
         } catch (Exception exception) {
             return Optional.empty();
         }
     }
-
 }

--- a/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/relocation/RelocationHandler.java
+++ b/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/relocation/RelocationHandler.java
@@ -30,7 +30,6 @@ import com.eternalcode.core.loader.dependency.Dependency;
 import com.eternalcode.core.loader.dependency.DependencyException;
 import com.eternalcode.core.loader.dependency.DependencyLoadResult;
 import com.eternalcode.core.loader.dependency.DependencyLoader;
-
 import com.eternalcode.core.loader.repository.Repository;
 import java.io.File;
 import java.io.IOException;
@@ -76,14 +75,14 @@ public class RelocationHandler implements AutoCloseable {
 
         Path relocatedJar = dependency.toMavenJar(localRepository, "relocated").toPath();
 
-        if (Files.exists(relocatedJar) && !this.cacheResolver.shouldForceRelocate(dependency, relocations)) {
+        if (Files.exists(relocatedJar) && !this.cacheResolver.shouldForceRelocate(relocations)) {
             return relocatedJar;
         }
 
-        return this.relocate(dependency, dependencyPath, relocatedJar, relocations);
+        return this.relocate(dependencyPath, relocatedJar, relocations);
     }
 
-    private Path relocate(Dependency dependency, Path input, Path output, List<Relocation> relocations) {
+    private Path relocate(Path input, Path output, List<Relocation> relocations) {
         Map<String, String> mappings = new HashMap<>();
 
         for (Relocation relocation : relocations) {
@@ -96,7 +95,7 @@ public class RelocationHandler implements AutoCloseable {
             Files.createFile(output);
             Object relocator = this.jarRelocatorConstructor.newInstance(input.toFile(), output.toFile(), mappings);
             this.jarRelocatorRunMethod.invoke(relocator);
-            this.cacheResolver.markAsRelocated(dependency, relocations);
+            this.cacheResolver.markAsRelocated(relocations);
 
             return output;
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | IOException exception) {

--- a/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/repository/LocalRepository.java
+++ b/eternalcore-plugin/src/main/java/com/eternalcode/core/loader/repository/LocalRepository.java
@@ -5,8 +5,11 @@ import java.nio.file.Path;
 
 public class LocalRepository extends Repository {
 
+    private final Path repositoryFolder;
+
     public LocalRepository(Path repositoryFolder) {
         super(assertFolder(repositoryFolder));
+        this.repositoryFolder = repositoryFolder;
     }
 
     private static String assertFolder(Path repositoryFolder) {
@@ -18,4 +21,7 @@ public class LocalRepository extends Repository {
         }
     }
 
+    public Path getRepositoryFolder() {
+        return repositoryFolder;
+    }
 }


### PR DESCRIPTION
Relocations are now tracked globally, potentially saving up to couple MB of data.

Fixes #1155
