### PR TITLE
GH-983 Add configurable settings for invalid usage message generation

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/configuration/implementation/PluginConfiguration.java
@@ -39,6 +39,8 @@ import com.eternalcode.core.feature.warp.WarpConfig;
 import com.eternalcode.core.feature.warp.WarpSettings;
 import com.eternalcode.core.injector.annotations.Bean;
 import com.eternalcode.core.injector.annotations.component.ConfigurationFile;
+import com.eternalcode.core.litecommand.handler.invalidusage.InvalidUsageConfig;
+import com.eternalcode.core.litecommand.handler.invalidusage.InvalidUsageSettings;
 import com.eternalcode.core.translation.TranslationConfig;
 import com.eternalcode.core.translation.TranslationSettings;
 import eu.okaeri.configs.OkaeriConfig;
@@ -78,6 +80,12 @@ public class PluginConfiguration extends AbstractConfigurationFile {
     @Comment("# Database Configuration")
     @Comment("# Settings responsible for the database connection")
     DatabaseConfig database = new DatabaseConfig();
+
+    @Bean(proxied = InvalidUsageSettings.class)
+    @Comment("")
+    @Comment("# Invalid usage message generation configuration")
+    @Comment("# Settings for command usage hinting")
+    InvalidUsageConfig invalidUsage = new InvalidUsageConfig();
 
     @Bean(proxied = SpawnJoinSettings.class)
     @Comment("")
@@ -234,6 +242,7 @@ public class PluginConfiguration extends AbstractConfigurationFile {
     @Comment("# Vanish Configuration")
     @Comment("# Settings responsible for player vanish functionality")
     VanishConfig vanish = new VanishConfig();
+
 
     @Override
     public File getConfigFile(File dataFolder) {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageConfig.java
@@ -1,0 +1,29 @@
+package com.eternalcode.core.litecommand.handler.invalidusage;
+
+import eu.okaeri.configs.OkaeriConfig;
+import eu.okaeri.configs.annotation.Comment;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
+@Getter
+@Accessors(fluent = true)
+public class InvalidUsageConfig extends OkaeriConfig implements InvalidUsageSettings {
+
+    @Comment({
+        "# How to display invalid usage hints:",
+        "# - MOST_RELEVANT: show only the most relevant (first) usage (default).",
+        "# - DETAILED: show header and a list of top N usages."
+    })
+    public InvalidUsageHintMode usageHintMode = InvalidUsageHintMode.MOST_RELEVANT;
+
+    @Comment({
+        "# When usageHintMode is DETAILED: maximum number of usages to show in the list."
+    })
+    public int detailedMaxEntries = 5;
+
+    @Comment({
+        "# When usageHintMode is DETAILED: whether to show the usage header before the list."
+    })
+    public boolean detailedShowHeader = true;
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageHandlerImpl.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageHandlerImpl.java
@@ -1,11 +1,11 @@
-package com.eternalcode.core.litecommand.handler;
+package com.eternalcode.core.litecommand.handler.invalidusage;
 
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.injector.annotations.lite.LiteHandler;
 import com.eternalcode.core.notice.NoticeService;
 import com.eternalcode.core.placeholder.Placeholders;
-import com.eternalcode.core.viewer.ViewerService;
 import com.eternalcode.core.viewer.Viewer;
+import com.eternalcode.core.viewer.ViewerService;
 import dev.rollczi.litecommands.handler.result.ResultHandlerChain;
 import dev.rollczi.litecommands.invalidusage.InvalidUsage;
 import dev.rollczi.litecommands.invalidusage.InvalidUsageHandler;
@@ -20,19 +20,30 @@ class InvalidUsageHandlerImpl implements InvalidUsageHandler<CommandSender> {
 
     private final ViewerService viewerService;
     private final NoticeService noticeService;
+    private final InvalidUsageSettings invalidUsageSettings;
 
     @Inject
-    InvalidUsageHandlerImpl(ViewerService viewerService, NoticeService noticeService) {
+    InvalidUsageHandlerImpl(
+        ViewerService viewerService,
+        NoticeService noticeService,
+        InvalidUsageSettings invalidUsageSettings
+    ) {
         this.viewerService = viewerService;
         this.noticeService = noticeService;
+        this.invalidUsageSettings = invalidUsageSettings;
     }
 
     @Override
-    public void handle(Invocation<CommandSender> invocation, InvalidUsage<CommandSender> result, ResultHandlerChain<CommandSender> chain) {
+    public void handle(
+        Invocation<CommandSender> invocation,
+        InvalidUsage<CommandSender> result,
+        ResultHandlerChain<CommandSender> chain) {
         Viewer viewer = this.viewerService.any(invocation.sender());
         Schematic schematic = result.getSchematic();
 
-        if (schematic.isOnlyFirst()) {
+        InvalidUsageHintMode mode = this.invalidUsageSettings.usageHintMode();
+
+        if (mode == InvalidUsageHintMode.MOST_RELEVANT || schematic.isOnlyFirst()) {
             this.noticeService.create()
                 .viewer(viewer)
                 .notice(translation -> translation.argument().usageMessage())
@@ -41,11 +52,21 @@ class InvalidUsageHandlerImpl implements InvalidUsageHandler<CommandSender> {
             return;
         }
 
-        this.noticeService.viewer(viewer, translation -> translation.argument().usageMessageHead());
+        if (this.invalidUsageSettings.detailedShowHeader()) {
+            this.noticeService.viewer(viewer, translation -> translation.argument().usageMessageHead());
+        }
+
+        int limit = Math.max(1, this.invalidUsageSettings.detailedMaxEntries());
+        int shown = 0;
 
         for (String schema : schematic.all()) {
-            this.noticeService.viewer(viewer, translation -> translation.argument().usageMessageEntry(), SCHEME.toFormatter(schema));
+            if (shown++ >= limit) {
+                break;
+            }
+            this.noticeService.viewer(
+                viewer,
+                translation -> translation.argument().usageMessageEntry(),
+                SCHEME.toFormatter(schema));
         }
     }
-
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageHintMode.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageHintMode.java
@@ -1,0 +1,6 @@
+package com.eternalcode.core.litecommand.handler.invalidusage;
+
+public enum InvalidUsageHintMode {
+    MOST_RELEVANT,
+    DETAILED
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageSettings.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/litecommand/handler/invalidusage/InvalidUsageSettings.java
@@ -1,0 +1,9 @@
+package com.eternalcode.core.litecommand.handler.invalidusage;
+
+public interface InvalidUsageSettings {
+    InvalidUsageHintMode usageHintMode();
+
+    int detailedMaxEntries();
+
+    boolean detailedShowHeader();
+}


### PR DESCRIPTION
Using `MOST_RELEVANT`:
<img width="744" height="107" alt="image" src="https://github.com/user-attachments/assets/49f5f3a3-33bb-456b-8b7f-13fc3ff6fe80" />


Using `DETAILED`:
<img width="657" height="94" alt="image" src="https://github.com/user-attachments/assets/48706bea-5d5e-4824-b8fb-9f7d065e240e" />

Video:


https://github.com/user-attachments/assets/d06ea7d6-6088-4f65-93b6-a20c7ed0bd94

