### PR TITLE
GH-1153 Rework delay system with per-entry Instant TTL

### DIFF
--- a/eternalcore-api/src/main/java/com/eternalcode/core/delay/DefaultDelay.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/delay/DefaultDelay.java
@@ -1,0 +1,63 @@
+package com.eternalcode.core.delay;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Represents a delay mechanism with a predefined default duration.
+ * <p>
+ * A key can be marked either with the default duration or with a custom one.
+ *
+ * @param <T> the type of key used to identify the delay
+ */
+public interface DefaultDelay<T> {
+
+    /**
+     * Marks a delay for the given key using the predefined default duration.
+     *
+     * @param key the key to mark
+     */
+    void markDelay(T key);
+
+    /**
+     * Removes any existing delay for the given key.
+     *
+     * @param key the key to unmark
+     */
+    void unmarkDelay(T key);
+
+    /**
+     * Checks if the given key currently has an active delay.
+     *
+     * @param key the key to check
+     * @return true if the key has a delay, false otherwise
+     */
+    boolean hasDelay(T key);
+
+    /**
+     * Returns the remaining duration of the delay for the given key.
+     * Returns {@code Duration.ZERO} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return remaining duration, or {@code Duration.ZERO} if none
+     */
+    Duration getRemaining(T key);
+
+    /**
+     * Returns the expiration time of the delay for the given key.
+     * Returns {@code null} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return expiration instant, or {@code null} if none
+     */
+    Instant getExpireAt(T key);
+
+    /**
+     * Extends the delay for the given key by the specified extra duration.
+     * If no active delay exists, a new one is created starting now.
+     *
+     * @param key   the key to extend
+     * @param extra the duration to add
+     */
+    void extendDelay(T key, Duration extra);
+}

--- a/eternalcore-api/src/main/java/com/eternalcode/core/delay/ExplicitDelay.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/delay/ExplicitDelay.java
@@ -1,0 +1,62 @@
+package com.eternalcode.core.delay;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Represents a delay mechanism where each key must be marked with an explicit duration.
+ *
+ * @param <T> the type of key used to identify the delay
+ */
+public interface ExplicitDelay<T> {
+
+    /**
+     * Marks a delay for the given key with the specified duration.
+     *
+     * @param key the key to mark
+     * @param duration the duration of the delay
+     */
+    void markDelay(T key, Duration duration);
+
+    /**
+     * Removes any existing delay for the given key.
+     *
+     * @param key the key to unmark
+     */
+    void unmarkDelay(T key);
+
+    /**
+     * Checks if the given key currently has an active delay.
+     *
+     * @param key the key to check
+     * @return true if the key has a delay, false otherwise
+     */
+    boolean hasDelay(T key);
+
+    /**
+     * Returns the remaining duration of the delay for the given key.
+     * Returns {@code Duration.ZERO} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return remaining duration, or {@code Duration.ZERO} if none
+     */
+    Duration getRemaining(T key);
+
+    /**
+     * Returns the expiration time of the delay for the given key.
+     * Returns {@code null} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return expiration instant, or {@code null} if none
+     */
+    Instant getExpireAt(T key);
+
+    /**
+     * Extends the delay for the given key by the specified extra duration.
+     * If no active delay exists, a new one is created starting now.
+     *
+     * @param key the key to extend
+     * @param extra the duration to add
+     */
+    void extendDelay(T key, Duration extra);
+}

--- a/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaDefaultDelay.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaDefaultDelay.java
@@ -1,0 +1,42 @@
+package com.eternalcode.core.delay;
+
+import java.time.Duration;
+
+/**
+ * DefaultDelay implementation backed by {@link GuavaDelay} using Guava cache.
+ * <p>
+ * Each key marked without explicit duration uses a predefined default delay.
+ *
+ * @param <T> the type of key used to identify the delay
+ */
+final class GuavaDefaultDelay<T> extends GuavaDelay<T> implements DefaultDelay<T> {
+
+    private final Duration defaultDelay;
+
+    /**
+     * Creates a new DefaultDelay with the specified default duration
+     * and the default maximum cache size.
+     *
+     * @param defaultDelay the default delay duration, must be positive
+     */
+    GuavaDefaultDelay(Duration defaultDelay) {
+        this(defaultDelay, DEFAULT_MAXIMUM_SIZE);
+    }
+
+    /**
+     * Creates a new DefaultDelay with the specified default duration
+     * and a custom maximum cache size.
+     *
+     * @param defaultDelay the default delay duration, must be positive
+     * @param maximumSize  maximum number of entries allowed in the cache
+     */
+    GuavaDefaultDelay(Duration defaultDelay, long maximumSize) {
+        super(defaultDelay, maximumSize);
+        this.defaultDelay = defaultDelay;
+    }
+
+    @Override
+    public void markDelay(T key) {
+        putDelay(key, this.defaultDelay);
+    }
+}

--- a/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaDelay.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaDelay.java
@@ -1,0 +1,174 @@
+package com.eternalcode.core.delay;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Base class providing shared logic for delay implementations using a Guava cache.
+ * <p>
+ * Each key is associated with an {@link Instant} representing the expiration time.
+ * Expired entries are cleaned up eagerly on read operations.
+ * <p>
+ * Contract:
+ * <ul>
+ *   <li>{@link #getRemaining(Object)} returns {@code Duration.ZERO} if no active delay exists.</li>
+ *   <li>{@link #getExpireAt(Object)} returns {@code null} if no active delay exists.</li>
+ *   <li>Durations &lt;= 0 in {@code putDelay} or {@code extendDelay} are treated as no delay (entry is removed).</li>
+ * </ul>
+ * <p>
+ * Thread-safe as guaranteed by Guava's {@link Cache}.
+ *
+ * @param <T> the type of key used to identify delays
+ */
+abstract class GuavaDelay<T> {
+
+    /** Default maximum number of cache entries. */
+    protected static final long DEFAULT_MAXIMUM_SIZE = 50_000L;
+
+    /** Underlying Guava cache mapping keys to expiration instants. */
+    protected final Cache<T, Instant> cache;
+
+    /**
+     * Creates a new BaseDelay with a custom maximum cache size.
+     *
+     * @param maximumSize the maximum number of entries in the cache must be greater than 0
+     */
+    protected GuavaDelay(long maximumSize) {
+        this.cache = CacheBuilder.newBuilder()
+            .maximumSize(maximumSize)
+            .build();
+    }
+
+    /**
+     * Creates a new BaseDelay with a custom expireAfterWrite and maximum cache size.
+     *
+     * @param maximumSize the maximum number of entries in the cache must be greater than 0
+     */
+    protected GuavaDelay(Duration expireAfter, long maximumSize) {
+        this.cache = CacheBuilder.newBuilder()
+            .maximumSize(maximumSize)
+            .expireAfterWrite(expireAfter)
+            .build();
+    }
+
+    /**
+     * Stores a delay until the given expiration instant.
+     *
+     * @param key      the key to mark
+     * @param expireAt the expiration instant
+     */
+    protected void putDelay(T key, Instant expireAt) {
+        this.cache.put(key, expireAt);
+    }
+
+    /**
+     * Stores a delay for the given duration starting from now.
+     * Durations &lt;= 0 are treated as no delay and will remove the entry.
+     *
+     * @param key      the key to mark
+     * @param duration the delay duration
+     */
+    protected void putDelay(T key, Duration duration) {
+        if (duration.isZero() || duration.isNegative()) {
+            this.cache.invalidate(key);
+            return;
+        }
+
+        this.cache.put(key, Instant.now().plus(duration));
+    }
+
+    /**
+     * Removes any existing delay for the given key.
+     *
+     * @param key the key to unmark
+     */
+    public void unmarkDelay(T key) {
+        this.cache.invalidate(key);
+    }
+
+    /**
+     * Checks if the given key currently has an active delay.
+     * Expired entries are removed on read.
+     *
+     * @param key the key to check
+     * @return true if an active delay exists, false otherwise
+     */
+    public boolean hasDelay(T key) {
+        Instant until = this.cache.getIfPresent(key);
+        if (until == null) {
+            return false;
+        }
+
+        if (Instant.now().isAfter(until)) {
+            this.cache.invalidate(key);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the remaining duration of the delay for the given key.
+     * Returns {@code Duration.ZERO} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return remaining duration, or {@code Duration.ZERO} if none
+     */
+    public Duration getRemaining(T key) {
+        Instant until = this.cache.getIfPresent(key);
+        if (until == null) {
+            return Duration.ZERO;
+        }
+
+        Duration left = Duration.between(Instant.now(), until);
+        if (left.isNegative() || left.isZero()) {
+            this.cache.invalidate(key);
+            return Duration.ZERO;
+        }
+
+        return left;
+    }
+
+    /**
+     * Returns the expiration instant of the delay for the given key.
+     * Returns {@code null} if no active delay exists.
+     *
+     * @param key the key to check
+     * @return expiration instant, or {@code null} if none
+     */
+    public Instant getExpireAt(T key) {
+        Instant until = this.cache.getIfPresent(key);
+        if (until == null) {
+            return null;
+        }
+
+        if (Instant.now().isAfter(until)) {
+            this.cache.invalidate(key);
+            return null;
+        }
+
+        return until;
+    }
+
+    /**
+     * Extends the delay for the given key by the specified duration.
+     * If no active delay exists, a new one is created starting now.
+     * Durations &lt;= 0 are ignored.
+     *
+     * @param key   the key to extend
+     * @param extra the duration to add
+     */
+    public void extendDelay(T key, Duration extra) {
+        if (extra.isZero() || extra.isNegative()) {
+            return;
+        }
+
+        Instant base = this.cache.getIfPresent(key);
+        Instant now = Instant.now();
+        Instant start = (base == null || now.isAfter(base)) ? now : base;
+        this.cache.put(key, start.plus(extra));
+    }
+}

--- a/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaExplicitDelay.java
+++ b/eternalcore-api/src/main/java/com/eternalcode/core/delay/GuavaExplicitDelay.java
@@ -1,0 +1,34 @@
+package com.eternalcode.core.delay;
+
+import java.time.Duration;
+
+/**
+ * ExplicitDelay implementation backed by {@link GuavaDelay} using Guava cache.
+ * <p>
+ * Each key must be marked with an explicit duration when creating a delay.
+ *
+ * @param <T> the type of key used to identify the delay
+ */
+final class GuavaExplicitDelay<T> extends GuavaDelay<T> implements ExplicitDelay<T> {
+
+    /**
+     * Creates a new ExplicitDelay with the default maximum cache size.
+     */
+    GuavaExplicitDelay() {
+        this(DEFAULT_MAXIMUM_SIZE);
+    }
+
+    /**
+     * Creates a new ExplicitDelay with a custom maximum cache size.
+     *
+     * @param maximumSize maximum number of entries allowed in the cache
+     */
+    GuavaExplicitDelay(long maximumSize) {
+        super(maximumSize);
+    }
+
+    @Override
+    public void markDelay(T key, Duration duration) {
+        putDelay(key, duration);
+    }
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/afk/AfkCommand.java
@@ -1,9 +1,8 @@
 package com.eternalcode.core.feature.afk;
 
-import static com.eternalcode.core.feature.afk.AfkCommand.AFK_BYPASS_PERMISSION;
-
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
 import com.eternalcode.annotations.scan.permission.PermissionDocs;
+import com.eternalcode.core.delay.DefaultDelay;
 import com.eternalcode.core.delay.Delay;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
@@ -12,9 +11,12 @@ import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Sender;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
+import org.bukkit.entity.Player;
+
 import java.time.Duration;
 import java.util.UUID;
-import org.bukkit.entity.Player;
+
+import static com.eternalcode.core.feature.afk.AfkCommand.AFK_BYPASS_PERMISSION;
 
 @Command(name = "afk")
 @Permission("eternalcore.afk")
@@ -30,14 +32,14 @@ class AfkCommand {
     private final NoticeService noticeService;
     private final AfkSettings afkSettings;
     private final AfkService afkService;
-    private final Delay<UUID> delay;
+    private final DefaultDelay<UUID> delay;
 
     @Inject
     AfkCommand(NoticeService noticeService, AfkSettings afkSettings, AfkService afkService) {
         this.noticeService = noticeService;
         this.afkSettings = afkSettings;
         this.afkService = afkService;
-        this.delay = new Delay<>(() -> this.afkSettings.afkCommandDelay());
+        this.delay = Delay.withDefault(this.afkSettings.afkCommandDelay());
     }
 
     @Execute
@@ -51,7 +53,7 @@ class AfkCommand {
         }
 
         if (this.delay.hasDelay(uuid)) {
-            Duration time = this.delay.getDurationToExpire(uuid);
+            Duration time = this.delay.getRemaining(uuid);
 
             this.noticeService
                 .create()
@@ -64,6 +66,6 @@ class AfkCommand {
         }
 
         this.afkService.switchAfk(uuid, AfkReason.COMMAND);
-        this.delay.markDelay(uuid, this.afkSettings.afkCommandDelay());
+        this.delay.markDelay(uuid);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/helpop/HelpOpCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/helpop/HelpOpCommand.java
@@ -2,6 +2,7 @@ package com.eternalcode.core.feature.helpop;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
 import com.eternalcode.annotations.scan.permission.PermissionDocs;
+import com.eternalcode.core.delay.DefaultDelay;
 import com.eternalcode.core.delay.Delay;
 import com.eternalcode.core.event.EventCaller;
 import com.eternalcode.core.feature.helpop.event.HelpOpEvent;
@@ -14,10 +15,11 @@ import dev.rollczi.litecommands.annotations.context.Sender;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.join.Join;
 import dev.rollczi.litecommands.annotations.permission.Permission;
-import java.time.Duration;
-import java.util.UUID;
 import org.bukkit.Server;
 import org.bukkit.entity.Player;
+
+import java.time.Duration;
+import java.util.UUID;
 
 @Command(name = "helpop", aliases = { "report" })
 @Permission("eternalcore.helpop")
@@ -34,7 +36,7 @@ class HelpOpCommand {
     private final HelpOpSettings helpOpSettings;
     private final EventCaller eventCaller;
     private final Server server;
-    private final Delay<UUID> delay;
+    private final DefaultDelay<UUID> delay;
 
     @Inject
     HelpOpCommand(NoticeService noticeService, HelpOpSettings helpOpSettings, EventCaller eventCaller, Server server) {
@@ -42,7 +44,7 @@ class HelpOpCommand {
         this.helpOpSettings = helpOpSettings;
         this.eventCaller = eventCaller;
         this.server = server;
-        this.delay = new Delay<>(() -> this.helpOpSettings.helpOpDelay());
+        this.delay = Delay.withDefault(this.helpOpSettings.helpOpDelay());
     }
 
     @Execute
@@ -58,7 +60,7 @@ class HelpOpCommand {
         }
 
         if (this.delay.hasDelay(uuid)) {
-            Duration time = this.delay.getDurationToExpire(uuid);
+            Duration time = this.delay.getRemaining(uuid);
 
             this.noticeService.create()
                 .notice(translation -> translation.helpOp().helpOpDelay())
@@ -91,7 +93,7 @@ class HelpOpCommand {
             .notice(translation -> translation.helpOp().send())
             .send();
 
-        this.delay.markDelay(uuid, this.helpOpSettings.helpOpDelay());
+        this.delay.markDelay(uuid);
     }
 
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/repair/RepairCommand.java
@@ -1,6 +1,7 @@
 package com.eternalcode.core.feature.repair;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
+import com.eternalcode.core.delay.DefaultDelay;
 import com.eternalcode.core.delay.Delay;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
@@ -9,8 +10,6 @@ import dev.rollczi.litecommands.annotations.command.Command;
 import dev.rollczi.litecommands.annotations.context.Sender;
 import dev.rollczi.litecommands.annotations.execute.Execute;
 import dev.rollczi.litecommands.annotations.permission.Permission;
-import java.time.Duration;
-import java.util.UUID;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -18,18 +17,21 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Repairable;
 
+import java.time.Duration;
+import java.util.UUID;
+
 @Command(name = "repair")
 class RepairCommand {
 
     private final NoticeService noticeService;
-    private final Delay<UUID> delay;
+    private final DefaultDelay<UUID> delay;
     private final RepairSettings repairSettings;
 
     @Inject
     RepairCommand(NoticeService noticeService, RepairSettings repairSettings) {
         this.noticeService = noticeService;
         this.repairSettings = repairSettings;
-        this.delay = new Delay<>(() -> this.repairSettings.repairDelay());
+        this.delay = Delay.withDefault(this.repairSettings.repairDelay());
     }
 
     @Execute
@@ -73,7 +75,7 @@ class RepairCommand {
             .player(player.getUniqueId())
             .send();
 
-        this.delay.markDelay(uuid, this.repairSettings.repairDelay());
+        this.delay.markDelay(uuid);
     }
 
     @Execute(name = "all")
@@ -117,7 +119,7 @@ class RepairCommand {
             .player(player.getUniqueId())
             .send();
 
-        this.delay.markDelay(uuid, this.repairSettings.repairDelay());
+        this.delay.markDelay(uuid);
     }
 
     @Execute(name = "armor")
@@ -161,12 +163,12 @@ class RepairCommand {
             .player(player.getUniqueId())
             .send();
 
-        this.delay.markDelay(uuid, this.repairSettings.repairDelay());
+        this.delay.markDelay(uuid);
     }
 
     private boolean hasRepairDelay(UUID uuid) {
         if (this.delay.hasDelay(uuid)) {
-            Duration time = this.delay.getDurationToExpire(uuid);
+            Duration time = this.delay.getRemaining(uuid);
 
             this.noticeService
                 .create()


### PR DESCRIPTION
## Description
This PR refactors the delay handling to eliminate cache-level TTL conflicts.

- Introduced GuavaDelay with shared logic on top of Guava Cache
- Removed `expireAfterWrite` to ensure TTL is controlled per entry via Instant
- Added separate interfaces: DefaultDelay (with predefined duration) and ExplicitDelay (explicit duration required)
- Implemented GuavaDefaultDelay and GuavaExplicitDelay
- Added Delay factory for convenient instance creation
- Clarified contract and documentation

Result: cleaner API, safer usage, no premature cache evictions.
Fixes #1153 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?
- [X] Localhost server

