### PR TITLE
GH-1332 feat: Add WeatherCommand for flexible weather control and persistence

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/ENTimeAndWeatherMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/ENTimeAndWeatherMessages.java
@@ -22,4 +22,8 @@ public class ENTimeAndWeatherMessages extends OkaeriConfig implements TimeAndWea
     Notice weatherSetSun = Notice.chat("<color:#9d6eef>► <white>Weather set to sun in the <color:#9d6eef>{WORLD}<white>!");
     Notice weatherSetThunder =
         Notice.chat("<color:#9d6eef>► <white>Weather set to thunder in the <color:#9d6eef>{WORLD}<white>!");
+    Notice weatherPersistenceEnabled =
+        Notice.chat("<color:#9d6eef>► <white>Locked <color:#9d6eef>{WEATHER}<white> weather in the <color:#9d6eef>{WORLD}<white> world.");
+    Notice weatherPersistenceDisabled =
+        Notice.chat("<color:#9d6eef>► <white>Natural weather cycle enabled again in the <color:#9d6eef>{WORLD}<white> world.");
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/PLTimeAndWeatherMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/PLTimeAndWeatherMessages.java
@@ -22,4 +22,8 @@ public class PLTimeAndWeatherMessages extends OkaeriConfig implements TimeAndWea
     Notice weatherSetSun =
         Notice.chat("<color:#9d6eef>► <white>Ustawiono słoneczną pogodę w świecie <color:#9d6eef>{WORLD}<white>!");
     Notice weatherSetThunder = Notice.chat("<color:#9d6eef>► <white>Ustawiono burze w świecie <color:#9d6eef>{WORLD}<white>!");
+    Notice weatherPersistenceEnabled =
+        Notice.chat("<color:#9d6eef>► <white>Zablokowano pogodę <color:#9d6eef>{WEATHER}<white> w świecie <color:#9d6eef>{WORLD}<white>.");
+    Notice weatherPersistenceDisabled =
+        Notice.chat("<color:#9d6eef>► <white>Przywrócono naturalny cykl pogody w świecie <color:#9d6eef>{WORLD}<white>!");
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/TimeAndWeatherMessages.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/time/messages/TimeAndWeatherMessages.java
@@ -12,4 +12,6 @@ public interface TimeAndWeatherMessages {
     Notice weatherSetRain();
     Notice weatherSetSun();
     Notice weatherSetThunder();
+    Notice weatherPersistenceEnabled();
+    Notice weatherPersistenceDisabled();
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/RainCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/RainCommand.java
@@ -1,7 +1,6 @@
 package com.eternalcode.core.feature.weather;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
-import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
 import com.eternalcode.core.viewer.Viewer;
@@ -18,12 +17,12 @@ import org.bukkit.World;
 class RainCommand {
 
     private final NoticeService noticeService;
-    private final MinecraftScheduler scheduler;
+    private final WeatherService weatherService;
 
     @Inject
-    RainCommand(NoticeService noticeService, MinecraftScheduler scheduler) {
+    RainCommand(NoticeService noticeService, WeatherService weatherService) {
         this.noticeService = noticeService;
-        this.scheduler = scheduler;
+        this.weatherService = weatherService;
     }
 
     @Execute
@@ -39,10 +38,7 @@ class RainCommand {
     }
 
     private void setRain(Viewer viewer, World world) {
-        this.scheduler.run(() -> {
-            world.setStorm(true);
-            world.setThundering(false);
-        });
+        this.weatherService.setWeather(world, WeatherType.RAIN, false);
 
         this.noticeService.create()
             .viewer(viewer)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/SunCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/SunCommand.java
@@ -1,7 +1,6 @@
 package com.eternalcode.core.feature.weather;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
-import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
 import com.eternalcode.core.viewer.Viewer;
@@ -18,12 +17,12 @@ import org.bukkit.World;
 class SunCommand {
 
     private final NoticeService noticeService;
-    private final MinecraftScheduler scheduler;
+    private final WeatherService weatherService;
 
     @Inject
-    SunCommand(NoticeService noticeService, MinecraftScheduler scheduler) {
+    SunCommand(NoticeService noticeService, WeatherService weatherService) {
         this.noticeService = noticeService;
-        this.scheduler = scheduler;
+        this.weatherService = weatherService;
     }
 
     @Execute
@@ -39,11 +38,7 @@ class SunCommand {
     }
 
     private void setSun(Viewer viewer, World world) {
-        this.scheduler.run(() -> {
-            world.setClearWeatherDuration(20 * 60 * 10);
-            world.setStorm(false);
-            world.setThundering(false);
-        });
+        this.weatherService.setWeather(world, WeatherType.SUN, false);
 
         this.noticeService.create()
             .viewer(viewer)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/ThunderCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/ThunderCommand.java
@@ -1,7 +1,6 @@
 package com.eternalcode.core.feature.weather;
 
 import com.eternalcode.annotations.scan.command.DescriptionDocs;
-import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
 import com.eternalcode.core.injector.annotations.Inject;
 import com.eternalcode.core.notice.NoticeService;
 import com.eternalcode.core.viewer.Viewer;
@@ -18,12 +17,12 @@ import org.bukkit.World;
 class ThunderCommand {
 
     private final NoticeService noticeService;
-    private final MinecraftScheduler scheduler;
+    private final WeatherService weatherService;
 
     @Inject
-    ThunderCommand(NoticeService noticeService, MinecraftScheduler scheduler) {
+    ThunderCommand(NoticeService noticeService, WeatherService weatherService) {
         this.noticeService = noticeService;
-        this.scheduler = scheduler;
+        this.weatherService = weatherService;
     }
 
     @Execute
@@ -39,10 +38,7 @@ class ThunderCommand {
     }
 
     private void setThunder(Viewer viewer, World world) {
-        this.scheduler.run(() -> {
-            world.setStorm(true);
-            world.setThundering(true);
-        });
+        this.weatherService.setWeather(world, WeatherType.THUNDER, false);
 
         this.noticeService.create()
             .viewer(viewer)

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherCommand.java
@@ -1,0 +1,94 @@
+package com.eternalcode.core.feature.weather;
+
+import com.eternalcode.annotations.scan.command.DescriptionDocs;
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.notice.NoticeService;
+import com.eternalcode.core.viewer.Viewer;
+import dev.rollczi.litecommands.annotations.argument.Arg;
+import dev.rollczi.litecommands.annotations.command.Command;
+import dev.rollczi.litecommands.annotations.context.Context;
+import dev.rollczi.litecommands.annotations.context.Sender;
+import dev.rollczi.litecommands.annotations.execute.Execute;
+import dev.rollczi.litecommands.annotations.flag.Flag;
+import dev.rollczi.litecommands.annotations.permission.Permission;
+import java.util.Locale;
+import org.bukkit.World;
+
+@Command(name = "weather")
+@Permission("eternalcore.weather")
+class WeatherCommand {
+
+    private final NoticeService noticeService;
+    private final WeatherService weatherService;
+
+    @Inject
+    WeatherCommand(NoticeService noticeService, WeatherService weatherService) {
+        this.noticeService = noticeService;
+        this.weatherService = weatherService;
+    }
+
+    @Execute
+    @DescriptionDocs(description = "Sets weather in current world", arguments = "<sun|rain|thunder> [-p]")
+    void execute(@Sender Viewer viewer, @Context World world, @Arg WeatherType weatherType, @Flag("-p") boolean persistent) {
+        this.setWeather(viewer, world, weatherType, persistent);
+    }
+
+    @Execute
+    @DescriptionDocs(description = "Sets weather in specified world", arguments = "<sun|rain|thunder> <world> [-p]")
+    void execute(
+        @Sender Viewer viewer,
+        @Arg WeatherType weatherType,
+        @Arg World world,
+        @Flag("-p") boolean persistent
+    ) {
+        this.setWeather(viewer, world, weatherType, persistent);
+    }
+
+    @Execute(name = "clear")
+    @DescriptionDocs(description = "Enables natural weather cycle in current world")
+    void clearCurrentWorld(@Sender Viewer viewer, @Context World world) {
+        this.clearWeather(viewer, world);
+    }
+
+    @Execute(name = "clear")
+    @DescriptionDocs(description = "Enables natural weather cycle in specified world", arguments = "<world>")
+    void clearSelectedWorld(@Sender Viewer viewer, @Arg World world) {
+        this.clearWeather(viewer, world);
+    }
+
+    private void setWeather(Viewer viewer, World world, WeatherType weatherType, boolean persistent) {
+        this.weatherService.setWeather(world, weatherType, persistent);
+
+        this.noticeService.create()
+            .viewer(viewer)
+            .placeholder("{WORLD}", world.getName())
+            .notice(translation -> switch (weatherType) {
+                case SUN -> translation.timeAndWeather().weatherSetSun();
+                case RAIN -> translation.timeAndWeather().weatherSetRain();
+                case THUNDER -> translation.timeAndWeather().weatherSetThunder();
+            })
+            .send();
+
+        if (!persistent) {
+            return;
+        }
+
+        this.noticeService.create()
+            .viewer(viewer)
+            .placeholder("{WORLD}", world.getName())
+            .placeholder("{WEATHER}", weatherType.name().toLowerCase(Locale.ROOT))
+            .notice(translation -> translation.timeAndWeather().weatherPersistenceEnabled())
+            .send();
+    }
+
+    private void clearWeather(Viewer viewer, World world) {
+        this.weatherService.clearPersistentWeather(world);
+
+        this.noticeService.create()
+            .viewer(viewer)
+            .placeholder("{WORLD}", world.getName())
+            .notice(translation -> translation.timeAndWeather().weatherPersistenceDisabled())
+            .send();
+    }
+
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherService.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherService.java
@@ -1,0 +1,51 @@
+package com.eternalcode.core.feature.weather;
+
+import com.eternalcode.commons.bukkit.scheduler.MinecraftScheduler;
+import com.eternalcode.core.injector.annotations.Inject;
+import com.eternalcode.core.injector.annotations.component.Service;
+import org.bukkit.GameRule;
+import org.bukkit.World;
+
+@Service
+class WeatherService {
+
+    private static final int DEFAULT_CLEAR_WEATHER_DURATION = 20 * 60 * 10;
+
+    private final MinecraftScheduler scheduler;
+
+    @Inject
+    WeatherService(MinecraftScheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    void setWeather(World world, WeatherType weatherType, boolean persistent) {
+        this.scheduler.run(() -> {
+            this.applyWeather(world, weatherType);
+            world.setGameRule(GameRule.DO_WEATHER_CYCLE, !persistent);
+        });
+    }
+
+    void clearPersistentWeather(World world) {
+        this.scheduler.run(() -> world.setGameRule(GameRule.DO_WEATHER_CYCLE, true));
+    }
+
+    private void applyWeather(World world, WeatherType weatherType) {
+        switch (weatherType) {
+            case SUN -> {
+                world.setClearWeatherDuration(DEFAULT_CLEAR_WEATHER_DURATION);
+                world.setStorm(false);
+                world.setThundering(false);
+            }
+            case RAIN -> {
+                world.setStorm(true);
+                world.setThundering(false);
+            }
+            case THUNDER -> {
+                world.setStorm(true);
+                world.setThundering(true);
+            }
+            default -> throw new IllegalStateException("Unsupported weather type: " + weatherType);
+        }
+    }
+
+}

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherType.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/weather/WeatherType.java
@@ -1,0 +1,7 @@
+package com.eternalcode.core.feature.weather;
+
+public enum WeatherType {
+    SUN,
+    RAIN,
+    THUNDER
+}


### PR DESCRIPTION
Added a new `/weather` command for simple world weather control.

Usage:
```text
/weather <sun|rain|thunder> [world] [-p]
/weather clear [world]
```

Behavior:
- Sets weather in the sender's current world or in a specified world.
- `-p` makes the weather persistent by disabling the natural weather cycle.
- `clear` re-enables the natural weather cycle for the target world.