### PR TITLE
GH-1334 Update settings comment and default permission check

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomeManager.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomeManager.java
@@ -157,6 +157,8 @@ public class HomeManager implements HomeService {
     public int getHomeLimit(Player player) {
         Map<String, Integer> maxHomes = this.homesSettings.maxHomes();
 
+        int defaultHomesLimit = maxHomes.getOrDefault("eternalcore.home.default",0);
+
         return maxHomes.entrySet().stream()
             .flatMap(entry -> {
                 if (player.hasPermission(entry.getKey())) {
@@ -166,6 +168,6 @@ public class HomeManager implements HomeService {
                 return Stream.empty();
             })
             .max(Integer::compareTo)
-            .orElse(0);
+            .orElse(defaultHomesLimit);
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomeManager.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomeManager.java
@@ -157,8 +157,6 @@ public class HomeManager implements HomeService {
     public int getHomeLimit(Player player) {
         Map<String, Integer> maxHomes = this.homesSettings.maxHomes();
 
-        int defaultHomesLimit = maxHomes.getOrDefault("eternalcore.home.default",0);
-
         return maxHomes.entrySet().stream()
             .flatMap(entry -> {
                 if (player.hasPermission(entry.getKey())) {
@@ -168,6 +166,6 @@ public class HomeManager implements HomeService {
                 return Stream.empty();
             })
             .max(Integer::compareTo)
-            .orElse(defaultHomesLimit);
+            .orElse(this.homesSettings.defaultLimit());
     }
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -42,7 +42,7 @@ public class HomesConfig extends OkaeriConfig implements HomesSettings {
         "# How it works:",
         "# If a player has both 'eternalcore.home.vip' and 'eternalcore.home.premium',",
         "# they will be able to set 3 homes (highest value wins).",
-        "# If the player does not have any permission from the list he will be able to set `defaultLimit` of homes.",
+        "# If the player does not have any permission from the list he will be able to set the limit defined by `defaultLimit`.",
         "#",
         "# You can define additional permissions as needed.",
         "# Example: 'eternalcore.home.admin: 999'"

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -47,12 +47,10 @@ public class HomesConfig extends OkaeriConfig implements HomesSettings {
         "# You can define additional permissions as needed.",
         "# Example: 'eternalcore.home.admin: 999'"
     })
-    public Map<String, Integer> maxHomes = new LinkedHashMap<>() {
-        {
-            put("eternalcore.home.vip", 2);
-            put("eternalcore.home.premium", 3);
-        }
-    };
+    public Map<String, Integer> maxHomes = Map.of(
+        "eternalcore.home.vip", 2,
+        "eternalcore.home.premium", 3
+    );
 
     @Comment({
         "# Default limit of homes used when the player does not have any permission from the list above."

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -3,7 +3,6 @@ package com.eternalcode.core.feature.home;
 import eu.okaeri.configs.OkaeriConfig;
 import eu.okaeri.configs.annotation.Comment;
 import java.time.Duration;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.Getter;
 import lombok.experimental.Accessors;

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -27,19 +27,26 @@ public class HomesConfig extends OkaeriConfig implements HomesSettings {
     public Duration delay = Duration.ofSeconds(5);
 
     @Comment({
-        "# Maximum number of homes per permission group",
-        "# Configure how many homes players can set based on their permissions",
-        "# ",
-        "# Permission format: 'permission' -> max_homes",
-        "# Players with higher permissions will get the highest limit they qualify for",
-        "# ",
-        "# Default permissions:",
-        "# - eternalcore.home.default: Basic players (1 home)",
+        "# Configure how many homes a player can set depending on their permissions.",
+        "#",
+        "# Permission format: 'permission.node : max_homes'",
+        "# If user has multiple permissions from the list the highest number will be taken",
+        "#",
+        "# Fallback behavior:",
+        "# - If a player does not have any of the listed permissions,",
+        "# the value from 'eternalcore.homes.default' will be used otherwise the limit will be 0.",
+        "#",
+        "# Example permissions:",
+        "# - eternalcore.home.default: All players (1 home)",
         "# - eternalcore.home.vip: VIP players (2 homes)",
         "# - eternalcore.home.premium: Premium players (3 homes)",
-        "# ",
-        "# You can add custom permission groups and limits as needed",
-        "# Example: 'eternalcore.home.admin' -> 999"
+        "# How it works:",
+        "# If a player has both 'eternalcore.home.vip' and 'eternalcore.home.premium',",
+        "# they will be able to set 3 homes (highest value wins).",
+        "# If the player does not have any permission from the group he will be able to set 1 home 'eternalcore.home.default",
+        "#",
+        "# You can define additional permissions as needed.",
+        "# Example: 'eternalcore.home.admin: 999'"
     })
     public Map<String, Integer> maxHomes = new LinkedHashMap<>() {
         {

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesConfig.java
@@ -34,25 +34,28 @@ public class HomesConfig extends OkaeriConfig implements HomesSettings {
         "#",
         "# Fallback behavior:",
         "# - If a player does not have any of the listed permissions,",
-        "# the value from 'eternalcore.homes.default' will be used otherwise the limit will be 0.",
+        "# the value from 'defaultLimit' will be used.",
         "#",
         "# Example permissions:",
-        "# - eternalcore.home.default: All players (1 home)",
         "# - eternalcore.home.vip: VIP players (2 homes)",
         "# - eternalcore.home.premium: Premium players (3 homes)",
         "# How it works:",
         "# If a player has both 'eternalcore.home.vip' and 'eternalcore.home.premium',",
         "# they will be able to set 3 homes (highest value wins).",
-        "# If the player does not have any permission from the group he will be able to set 1 home 'eternalcore.home.default",
+        "# If the player does not have any permission from the list he will be able to set `defaultLimit` of homes.",
         "#",
         "# You can define additional permissions as needed.",
         "# Example: 'eternalcore.home.admin: 999'"
     })
     public Map<String, Integer> maxHomes = new LinkedHashMap<>() {
         {
-            put("eternalcore.home.default", 1);
             put("eternalcore.home.vip", 2);
             put("eternalcore.home.premium", 3);
         }
     };
+
+    @Comment({
+        "# Default limit of homes used when the player does not have any permission from the list above."
+    })
+    public Integer defaultLimit = 1;
 }

--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesSettings.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/home/HomesSettings.java
@@ -7,4 +7,5 @@ public interface HomesSettings {
     Map<String, Integer> maxHomes();
     Duration delay();
     String defaultName();
+    Integer defaultLimit();
 }


### PR DESCRIPTION
## Description

Create better documentation for max homes list. Add default permission that is optional for max homes limit.

Fixes # (issue)

No default permission available - discord support 09.04.2026

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Tested default permission, vip and premium with LuckPerms.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to readme etc.
- [x] My changes generate no new warnings
- [ ] I have added test to cover my changes - **NOT DONE**
- [ ] I have added appropriate labels to this Pull Request

