### PR TITLE
GH-1382 require distinct permission to enchant another player's item

### DIFF
--- a/eternalcore-core/src/main/java/com/eternalcode/core/feature/enchant/EnchantCommand.java
+++ b/eternalcore-core/src/main/java/com/eternalcode/core/feature/enchant/EnchantCommand.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 
 @Command(name = "enchant")
-@Permission("eternalcore.enchant")
 class EnchantCommand {
 
     private final EnchantSettings enchantSettings;
@@ -28,6 +27,7 @@ class EnchantCommand {
     }
 
     @Execute
+    @Permission("eternalcore.enchant")
     @DescriptionDocs(description = "Enchants item in hand", arguments = "<enchantment> <level>")
     void execute(@Sender Player player, @Arg Enchantment enchantment, @Arg(EnchantLevelArgument.KEY) int level) {
         PlayerInventory playerInventory = player.getInventory();
@@ -51,7 +51,8 @@ class EnchantCommand {
     }
 
     @Execute
-    @DescriptionDocs(description = "Enchants item in hand", arguments = "<enchantment> <level> <player>")
+    @Permission("eternalcore.enchant.other")
+    @DescriptionDocs(description = "Enchants the item held by the specified player", arguments = "<enchantment> <level> <player>")
     void execute(@Sender Player sender, @Arg Enchantment enchantment, @Arg(EnchantLevelArgument.KEY) int level, @Arg Player target) {
         PlayerInventory targetInventory = target.getInventory();
         ItemStack handItem = targetInventory.getItem(targetInventory.getHeldItemSlot());


### PR DESCRIPTION
Both /enchant execute overloads were gated only by the class-level
@Permission("eternalcore.enchant"), so anyone allowed to enchant their own
item could also modify other players' held items.

Follow the FlyCommand convention: drop the class-level permission and gate
each overload individually — eternalcore.enchant for the self variant and
eternalcore.enchant.other for the "<player>" variant.

Note: servers that previously granted eternalcore.enchant to allow enchanting
others must now also grant eternalcore.enchant.other.
